### PR TITLE
Change root page on calculators

### DIFF
--- a/app/controllers/admins/calculators_controller.rb
+++ b/app/controllers/admins/calculators_controller.rb
@@ -2,10 +2,10 @@
 
 module Admins
   class CalculatorsController < ApplicationController
-    before_action :find_calculator, except: %i[new create]
+    before_action :find_calculator, except: %i[new create index]
     layout 'admin'
 
-     def index
+    def index
       @calculators = if params[:search]
         Calculator.where('name LIKE ?', "%#{params[:search]}%")
       else

--- a/app/controllers/admins/calculators_controller.rb
+++ b/app/controllers/admins/calculators_controller.rb
@@ -2,7 +2,7 @@
 
 module Admins
   class CalculatorsController < ApplicationController
-    before_action :find_calculator, except: %i[new create index]
+    before_action :find_calculator, except: %i[new create]
     layout 'admin'
 
     def index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  root 'admins/calculators#index'
+
   devise_for :admins, controllers: { sessions: 'admins/sessions' }
 
   devise_for :users, controllers: { registrations: 'users/registrations',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  root 'admins/calculators#index'
+  root 'calculators#index'
 
   devise_for :admins, controllers: { sessions: 'admins/sessions' }
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,18 +86,6 @@ ActiveRecord::Schema.define(version: 2021_09_23_171630) do
     t.index ["uuid"], name: "index_products_on_uuid", unique: true
   end
 
-  create_table "user_infos", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_user_infos_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_user_infos_on_reset_password_token", unique: true
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Actual result: root page is rails app default page. And we don't need it

Expected result: Root page should be /calculators.

## Summary of change

Changed root page on calculators

## Testing approach



## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
