### PR TITLE
ZER-113/Fixed flash messages on sign in page bug

### DIFF
--- a/app/views/layouts/_flash_messages.html.slim
+++ b/app/views/layouts/_flash_messages.html.slim
@@ -1,5 +1,5 @@
 - flash_messages.each do |message_type, message|
-  .alert.alert-dismissible.fade.show.position-absolute.container-fluid class=(message_class_by_name(message_type))
+  .alert.alert-dismissible.fade.show.position-absolute.container-fluid.fixed-top class=(message_class_by_name(message_type))
     = message
     button.close[type="button" data-dismiss="alert" aria-label="Close"]
       span[aria-hidden="true"]

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,8 +9,7 @@ html
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body.wrapper
-    = render 'layouts/navigation'
     = render 'layouts/flash_messages'
-
+    = render 'layouts/navigation'
     = yield
     = render 'layouts/footer'

--- a/spec/features/sign_out_spec.rb
+++ b/spec/features/sign_out_spec.rb
@@ -5,13 +5,16 @@ require 'rails_helper'
 describe 'sign out', js: true do
   let(:user) { create(:user) }
   let(:calculator) { create(:calculator) }
+  flash_message_disappear_time = 10
   before do
     allow_any_instance_of(ApplicationController).to receive(:after_sign_in_path_for).and_return("/calculators/#{calculator.slug}")
     visit '/users/sign_in'
     fill_in 'Email', with: user.email
     fill_in 'Password', with: user.password
     click_button 'Log in'
-    click_link 'Log Out'
+    Capybara.using_wait_time flash_message_disappear_time do
+      click_link 'Log Out'
+    end
   end
 
   it "signs the user out" do


### PR DESCRIPTION
dev
## JIRA

* [ZER-113](https://jira.softserve.academy/browse/ZER-113)

## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Amend flash messages behavior

## Summary of change

1. Changed the flash messages styles to the dismissing bootstrap alerts.
2. Added jQuery method to clear flash messages after 10 seconds.

## Testing approach

Changed the sign out tests due to the flash messages behavior

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
