### PR TITLE
ZER-134 Fix wrong number of months for child's 2 years

### DIFF
--- a/app/javascript/ajax/calculate_result_button.js
+++ b/app/javascript/ajax/calculate_result_button.js
@@ -2,24 +2,47 @@ $(document).on('turbolinks:load', function() {
   const form = document.getElementById('form');
   const childs_years = document.getElementById('childs_years');
   const childs_months = document.getElementById('childs_months');
+  const two_years_childs_months = document.getElementById('two_years_childs_months');
+  
   if (!form) {
     return
   }
-  childs_years.addEventListener('click',() => {
-    if(childs_years.value < 2) {
-      childs_months.classList.remove('last-year');
+
+  two_years_childs_months.classList.add('hidden')
+  two_years_childs_months.required = false
+  
+  childs_years.addEventListener('input', () => {
+    if (childs_years.value == 2) {
+      childs_months.classList.add('hidden')
+      childs_months.required = false
+
+      two_years_childs_months.classList.remove('hidden')
+      two_years_childs_months.required = true
     } else {
-      childs_months.selectedIndex = 0;
-      childs_months.classList.add('last-year');
+      two_years_childs_months.classList.add('hidden')
+      two_years_childs_months.required = false
+
+      childs_months.classList.remove('hidden')
+      childs_months.required = true
     }
   });
+
   form.addEventListener('submit', function(e) {
 
     e.preventDefault();
 
-    const formData = {
-      childs_age: $("#childs_years").val() * 12 + (+$("#childs_months").val())
+    let months = 0;
+
+    if (childs_years.value == 2) {
+      months = (+$("#two_years_childs_months").val());
+    } else {
+      months = (+$("#childs_months").val())
     }
+
+    const formData = {
+      childs_age: $("#childs_years").val() * 12 + months
+    }
+
     $.ajax({
       url: "/api/v1/diaper_calculators",
       type: "POST",

--- a/app/javascript/css/calculator.css.scss
+++ b/app/javascript/css/calculator.css.scss
@@ -72,6 +72,10 @@
   display: none;
 }
 
+.hidden {
+  display: none;
+}
+
 #date {
   width:236px;
   padding-left: 20px;

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -17,13 +17,20 @@
                 option value = year
                   = year
                   = t('.form.years')
-            select.custom-select#childs_months [required]
+            select.custom-select#childs_months
               option [disabled selected value]
                 =t('.form.childs_months_label')
               - (0..11).each do |month|
                 option value = month
                   = month
                   = t('.form.months')
+            select.custom-select#two_years_childs_months
+              option [disabled selected value]
+                =t('.form.childs_months_label')
+                - (0..6).each do |month|
+                  option value = month
+                    = month
+                    = t('.form.months')
             = form.text_field :baby_weight, placeholder:t('.form.baby_weight_label'), class:"form-input d-none"
             = form.text_field :diapers_per_day, placeholder: "Diapers per day", class:"form-input d-none"
           = render_email_receiver_checkbox


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/browse/ZER-134)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

When choosing 2 years in the calculator, make only 0-6 months appear instead of 0-11.

## Summary of change

Update calcualte_result_button.js to include logic of understanding the year, that the user has chosen. In calculator.html.slim create extra "option" with 0-6 months only.

Before:

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/46069566/180184970-7d45a3e7-2df1-438a-8a45-3ec1a52b1a24.png">


After:

<img width="1424" alt="after" src="https://user-images.githubusercontent.com/46069566/180184916-5208dfc9-7efb-4344-a772-7f3ea37a27f5.png">

## Testing approach

Code written only in JS.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions