### PR TITLE
ZER-176 Add space up and under Logo

### DIFF
--- a/app/views/layouts/_navigation.html.slim
+++ b/app/views/layouts/_navigation.html.slim
@@ -1,6 +1,6 @@
 body
   header.page-header
-    = link_to image_tag('logo-zerowaste.jpg'), root_path, class: 'logo-zerowaste'
+    = link_to image_tag('logo-zerowaste.jpg'), root_path, class: 'logo-zerowaste py-4'
     .tabs
       - if FeatureFlag.get('show_admin_menu').active?
         - if user_signed_in?


### PR DESCRIPTION

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)
* [ZER-176](https://jira.softserve.academy/browse/ZER-176)

## Code reviewers

- [ ] @loqimean 

## Summary of issue

 * No space available up and under Logo.
 
![image-2022-10-16-18-06-56-335](https://user-images.githubusercontent.com/70696653/198256322-6fcec33f-c7a0-44e5-8b1f-742efc39ae7e.png)


## Summary of change

Add padding value to logo using bootstrap.

```
    = link_to image_tag('logo-zerowaste.jpg'), root_path, class: 'logo-zerowaste py-4'
```
![IMG_20221027_130124_353](https://user-images.githubusercontent.com/70696653/198255323-5c4e1348-4140-430a-a622-04f077539a52.jpg)

## Testing approach

ToDo

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions

