### PR TITLE
ZER-182 fix(main.css.scss) taken away defect of darkening background image

### DIFF
--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -4,7 +4,7 @@ body {
   background: url("../images/mother.jpeg") no-repeat center top;
   background-size: cover;
   overflow-x: hidden;
-  min-height: 100%;
+  height: 100%;
 }
 
 a {
@@ -23,7 +23,8 @@ a {
 .filter_block {
   position: absolute;
   background-color: #00000078;
-  height: 100%;
+  height: auto !important;
+  min-height: 100%;
   width: 100%;
   top: 0;
   left: 0;

--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -4,7 +4,7 @@ body {
   background: url("../images/mother.jpeg") no-repeat center top;
   background-size: cover;
   overflow-x: hidden;
-  height: 100%;
+  height: 100vh;
 }
 
 a {
@@ -23,7 +23,6 @@ a {
 .filter_block {
   position: absolute;
   background-color: #00000078;
-  height: auto !important;
   min-height: 100%;
   width: 100%;
   top: 0;

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -149,8 +149,8 @@ ActiveRecord::Schema.define(version: 2022_10_26_072654) do
     t.string "provider"
     t.string "uid"
     t.boolean "blocked", default: false
-    t.boolean "receive_recomendations", default: false
     t.integer "role", default: 0
+    t.boolean "receive_recomendations", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
dev
## JIRA

* [ZER-182](https://jira.softserve.academy/browse/ZER-182)


## Code reviewers

- [ ] @loqimean 

## Summary of issue

When the screen is horizontally oriented, the upper part of the background image is darkened, the lower part is light (see screenshot).
![image](https://user-images.githubusercontent.com/106908913/199238539-9e3d875f-0fe5-4445-9558-c8da203bf495.png)

## Summary of change

When the screen is horizontally oriented, background image is darkened
![image](https://user-images.githubusercontent.com/106908913/199239782-333a4114-0eec-4bed-8a4d-333ca41f4031.png)

## Testing approach

ToDo

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
