### PR TITLE
ZER-185 Change text in drop down lists in data input block

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,9 @@ Metrics/AbcSize:
   Enabled: true
   Max: 31
 
+Layout/EndOfLine:
+  EnforcedStyle: crlf
+
 Layout/LineLength:
   Enabled: true
   Max: 80
@@ -66,4 +69,3 @@ Layout/SpaceInsideReferenceBrackets:
 
 Metrics/BlockLength:
   IgnoredMethods: ['describe', 'context']
-  

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -8,19 +8,19 @@
       = form_with url: "#", id: "form", method: :get do |form|
         .flex-item
           select.custom-select#childs_years [required]
-            option [disabled selected value]
+            option [disabled selected hidden value]
               = t('.form.childs_years_label')
             - (0..2).each do |year|
               option value = year
                 = t('calculators.calculator.form.years', count: year)
           select.custom-select#childs_months
-            option [disabled selected value]
+            option [disabled selected hidden value]
               =t('.form.childs_months_label')
             - (0..11).each do |month|
               option value = month
                 = t('calculators.calculator.form.months', count: month)
           select.custom-select#two_years_childs_months
-            option [disabled selected value]
+            option [disabled selected hidden value]
               =t('.form.childs_months_label')
             - (0..6).each do |month|
               option value = month

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -12,19 +12,19 @@
               = t('.form.childs_years_label')
             - (0..2).each do |year|
               option value = year
-                = t('datetime.distance_in_words.x_years', count: year)
+                = "#{year} #{t('datetime.prompts.year').downcase.pluralize(year, I18n.locale)}"
           select.custom-select#childs_months
             option [disabled selected hidden value]
               =t('.form.childs_months_label')
             - (0..11).each do |month|
               option value = month
-                = t('datetime.distance_in_words.x_months', count: month)
+                = "#{month} #{t('datetime.prompts.month').downcase.pluralize(month, I18n.locale)}"
           select.custom-select#two_years_childs_months
             option [disabled selected hidden value]
               =t('.form.childs_months_label')
             - (0..6).each do |month|
               option value = month
-                = t('datetime.distance_in_words.x_months', count: month)
+                = "#{month} #{t('datetime.prompts.month').downcase.pluralize(month, I18n.locale)}"
 
           - if FeatureFlag.get('feature_budget_category').active?
             p.form-a

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -12,19 +12,19 @@
               = t('.form.childs_years_label')
             - (0..2).each do |year|
               option value = year
-                = "#{year} #{t('datetime.prompts.year').downcase.pluralize(year, I18n.locale)}"
+                = "#{year} #{t('datetime.prompts.year').downcase.pluralize(count: year, locale: I18n.locale)}"
           select.custom-select#childs_months
             option [disabled selected hidden value]
               =t('.form.childs_months_label')
             - (0..11).each do |month|
               option value = month
-                = "#{month} #{t('datetime.prompts.month').downcase.pluralize(month, I18n.locale)}"
+                = "#{month} #{t('datetime.prompts.month').downcase.pluralize(count: month, locale: I18n.locale)}"
           select.custom-select#two_years_childs_months
             option [disabled selected hidden value]
               =t('.form.childs_months_label')
             - (0..6).each do |month|
               option value = month
-                = "#{month} #{t('datetime.prompts.month').downcase.pluralize(month, I18n.locale)}"
+                = "#{month} #{t('datetime.prompts.month').downcase.pluralize(count: month, locale: I18n.locale)}"
 
           - if FeatureFlag.get('feature_budget_category').active?
             p.form-a

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -12,19 +12,19 @@
               = t('.form.childs_years_label')
             - (0..2).each do |year|
               option value = year
-                = year
+                = t('calculators.calculator.form.years', count: year)
           select.custom-select#childs_months
             option [disabled selected value]
               =t('.form.childs_months_label')
             - (0..11).each do |month|
               option value = month
-                = month
+                = t('calculators.calculator.form.months', count: month)
           select.custom-select#two_years_childs_months
             option [disabled selected value]
               =t('.form.childs_months_label')
             - (0..6).each do |month|
               option value = month
-                = month
+                = t('calculators.calculator.form.months', count: month)
 
           - if FeatureFlag.get('feature_budget_category').active?
             p.form-a

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -12,19 +12,19 @@
               = t('.form.childs_years_label')
             - (0..2).each do |year|
               option value = year
-                = t('calculators.calculator.form.years', count: year)
+                = t('datetime.distance_in_words.x_years', count: year)
           select.custom-select#childs_months
             option [disabled selected hidden value]
               =t('.form.childs_months_label')
             - (0..11).each do |month|
               option value = month
-                = t('calculators.calculator.form.months', count: month)
+                = t('datetime.distance_in_words.x_months', count: month)
           select.custom-select#two_years_childs_months
             option [disabled selected hidden value]
               =t('.form.childs_months_label')
             - (0..6).each do |month|
               option value = month
-                = t('calculators.calculator.form.months', count: month)
+                = t('datetime.distance_in_words.x_months', count: month)
 
           - if FeatureFlag.get('feature_budget_category').active?
             p.form-a

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -15,3 +15,12 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+require 'inflector_extensions'
+
+ActiveSupport::Inflector.inflections(:uk) do |inflect|
+  inflect.plural('місяць', 'місяців', (5..11).to_a << 0)
+  inflect.plural('місяць', 'місяці', (2..4).to_a)
+  inflect.plural('рік', 'років', [0])
+  inflect.plural('рік', 'роки', [2])
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,12 +43,6 @@ en:
         budgetary: "budgetary"
         medium: "medium"
         premium: "premium"
-        years:
-          one: "1 year"
-          other: "%{count} years"
-        months:
-          one: "1 month"
-          other: "%{count} months"
       calculate_result_button: "Calculate"
       want_recomentation_label: "Yes, I want to receive email messages with recommendations"
       bought_diapers: "diapers already used"
@@ -401,3 +395,211 @@ en:
   #   formats:
   #     long: '%A, %d %B, %Y'
   #     short: '%d, %B, %Y'
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
+      x_years:
+        one: 1 year
+        other: "%{count} years"
+    prompts:
+      second: Second
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      in: must be in %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: 'Validation failed: %{errors}'
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,12 @@ en:
         budgetary: "budgetary"
         medium: "medium"
         premium: "premium"
+        years:
+          one: "1 year"
+          other: "%{count} years"
+        months:
+          one: "1 month"
+          other: "%{count} months"
       calculate_result_button: "Calculate"
       want_recomentation_label: "Yes, I want to receive email messages with recommendations"
       bought_diapers: "diapers already used"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -19,7 +19,7 @@ uk:
         months:
           one: "1 місяць"
           few: "%{count} місяці"
-          many: "%{count}"
+          many: "%{count} місяців"
       calculate_result_button: "Розрахувати"
       want_recomentation_label: "Так, я хочу отримувати листи з рекомендаціями"
       bought_diapers: "підгузок ви вже використали"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -12,6 +12,14 @@ uk:
         budgetary: "бюджетна"
         medium: "середня"
         premium: "преміум"
+        years:
+          zero: "0 років"
+          one: "1 рік"
+          few: "%{count} роки"
+        months:
+          one: "1 місяць"
+          few: "%{count} місяці"
+          many: "%{count}"
       calculate_result_button: "Розрахувати"
       want_recomentation_label: "Так, я хочу отримувати листи з рекомендаціями"
       bought_diapers: "підгузок ви вже використали"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -12,14 +12,6 @@ uk:
         budgetary: "бюджетна"
         medium: "середня"
         premium: "преміум"
-        years:
-          one: "%{count} рік"
-          few: "%{count} роки"
-          many: "%{count} років"
-        months:
-          one: "%{count} місяць"
-          few: "%{count} місяці"
-          many: "%{count} місяців"
       calculate_result_button: "Розрахувати"
       want_recomentation_label: "Так, я хочу отримувати листи з рекомендаціями"
       bought_diapers: "підгузок ви вже використали"
@@ -311,6 +303,12 @@ uk:
         name: "Назва"
         slug: "Шлях"
         preferable: "Бажаний"
+    errors:
+      messages:
+        record_invalid: 'Виникли помилки: %{errors}'
+        restrict_dependent_destroy:
+          has_one: 'Неможливо видалити запис, так як існує залежність: %{record}'
+          has_many: 'Неможливо видалити запис, так як існують залежності: %{record}'
   notifications:
     calculator_created: "Калькулятор було успішно створено"
     calculator_updated: "Калькулятор було успішно оновлено"
@@ -320,3 +318,260 @@ uk:
   #   formats:
   #     long: '%A, %d %B, %Y'
   #     short: '%d, %B, %Y'
+  date:
+    abbr_day_names:
+    - нд.
+    - пн.
+    - вт.
+    - ср.
+    - чт.
+    - пт.
+    - сб.
+    abbr_month_names:
+    -
+    - січ.
+    - лют.
+    - бер.
+    - квіт.
+    - трав.
+    - черв.
+    - лип.
+    - серп.
+    - вер.
+    - жовт.
+    - лист.
+    - груд.
+    day_names:
+    - неділя
+    - понеділок
+    - вівторок
+    - середа
+    - четвер
+    - п'ятниця
+    - субота
+    formats:
+      default: "%d.%m.%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
+    month_names:
+    -
+    - Січня
+    - Лютого
+    - Березня
+    - Квітня
+    - Травня
+    - Червня
+    - Липня
+    - Серпня
+    - Вересня
+    - Жовтня
+    - Листопада
+    - Грудня
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: близько %{count} години
+        few: близько %{count} годин
+        many: близько %{count} годин
+        other: близько %{count} години
+      about_x_months:
+        one: близько %{count} місяця
+        few: близько %{count} місяців
+        many: близько %{count} місяців
+        other: близько %{count} місяця
+      about_x_years:
+        one: близько %{count} року
+        few: близько %{count} років
+        many: близько %{count} років
+        other: близько %{count} року
+      almost_x_years:
+        one: майже %{count} рік
+        few: майже %{count} роки
+        many: майже %{count} років
+        other: майже %{count} років
+      half_a_minute: пів хвилини
+      less_than_x_seconds:
+        one: менше %{count} секунди
+        few: менше %{count} секунд
+        many: менше %{count} секунд
+        other: менше %{count} секунди
+      less_than_x_minutes:
+        one: менше %{count} хвилини
+        few: менше %{count} хвилин
+        many: менше %{count} хвилин
+        other: менше %{count} хвилини
+      over_x_years:
+        one: більше %{count} року
+        few: більше %{count} років
+        many: більше %{count} років
+        other: більше %{count} року
+      x_seconds:
+        one: "%{count} секунда"
+        few: "%{count} секунди"
+        many: "%{count} секунд"
+        other: "%{count} секунди"
+      x_minutes:
+        one: "%{count} хвилина"
+        few: "%{count} хвилини"
+        many: "%{count} хвилин"
+        other: "%{count} хвилини"
+      x_days:
+        one: "%{count} день"
+        few: "%{count} дні"
+        many: "%{count} днів"
+        other: "%{count} дня"
+      x_months:
+        one: "%{count} місяць"
+        few: "%{count} місяці"
+        many: "%{count} місяців"
+        other: "%{count} місяця"
+      x_years:
+        one: "%{count} рік"
+        few: "%{count} роки"
+        many: "%{count} років"
+        other: "%{count} року"
+    prompts:
+      second: Секунда
+      minute: Хвилина
+      hour: Година
+      day: День
+      month: Місяць
+      year: Рік
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: має бути прийнятий
+      blank: не може бути пустим
+      confirmation: не збігається з підтвердженням
+      empty: не може бути порожнім
+      equal_to: має дорівнювати %{count}
+      even: має бути парним
+      exclusion: зарезервовано
+      greater_than: має бути більше ніж %{count}
+      greater_than_or_equal_to: має бути більше ніж або дорівнювати %{count}
+      inclusion: не включено до переліку
+      invalid: недійсний
+      less_than: має бути менше ніж %{count}
+      less_than_or_equal_to: має бути менше ніж або дорівнювати %{count}
+      model_invalid: 'Виникли помилки: %{errors}'
+      not_a_number: не число
+      not_an_integer: не є цілим числом
+      odd: має бути непарним
+      other_than: має відрізнятись від %{count}
+      present: має бути пустим
+      required: не може бути порожнім
+      taken: вже зайнятий
+      too_long:
+        one: занадто довгий (максимум %{count} знак)
+        few: занадто довгий (максимум %{count} знаки)
+        many: занадто довгий (максимум %{count} знаків)
+        other: занадто довгий (максимум %{count} знаку)
+      too_short:
+        one: занадто короткий (мінімум %{count} знак)
+        few: занадто короткий (мінімум %{count} знаки)
+        many: занадто короткий (мінімум %{count} знаків)
+        other: занадто короткий (мінімум %{count} знаку)
+      wrong_length:
+        one: неправильна довжина (має бути %{count} знак)
+        few: неправильна довжина (має бути %{count} знаки)
+        many: неправильна довжина (має бути %{count} знаків)
+        other: неправильна довжина (має бути %{count} знаку)
+    template:
+      body: 'Помилки виявлено в таких полях:'
+      header:
+        one: "%{model} не збережено через %{count} помилку"
+        few: "%{model} не збережено через %{count} помилки"
+        many: "%{model} не збережено через %{count} помилок"
+        other: "%{model} не збережено через %{count} помилки"
+  helpers:
+    select:
+      prompt: 'Оберіть: '
+    submit:
+      create: Створити %{model}
+      submit: Зберегти %{model}
+      update: Зберегти %{model}
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: грн.
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: Мільярд
+            few: Мільярдів
+            many: Мільярдів
+            other: Мільярдів
+          million:
+            one: Мільйон
+            few: Мільйонів
+            many: Мільйонів
+            other: Мільйонів
+          quadrillion:
+            one: Квадрильйон
+            few: Квадрильйонів
+            many: Квадрильйонів
+            other: Квадрильйонів
+          thousand:
+            one: Тисяча
+            few: Тисяч
+            many: Тисяч
+            other: Тисяч
+          trillion:
+            one: Трильйон
+            few: Трильйонів
+            many: Трильйонів
+            other: Трильйонів
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: байт
+            few: байти
+            many: байтів
+            other: байту
+          gb: ГБ
+          kb: кБ
+          mb: МБ
+          tb: ТБ
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " та "
+      two_words_connector: " і "
+      words_connector: ", "
+  time:
+    am: до полудня
+    formats:
+      default: "%a, %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y, %H:%M"
+      short: "%d %b, %H:%M"
+    pm: по полудні

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -13,11 +13,11 @@ uk:
         medium: "середня"
         premium: "преміум"
         years:
-          zero: "0 років"
-          one: "1 рік"
+          one: "%{count} рік"
           few: "%{count} роки"
+          many: "%{count} років"
         months:
-          one: "1 місяць"
+          one: "%{count} місяць"
           few: "%{count} місяці"
           many: "%{count} місяців"
       calculate_result_button: "Розрахувати"

--- a/lib/inflector_extensions.rb
+++ b/lib/inflector_extensions.rb
@@ -19,12 +19,14 @@ module InflectorExtensions
   def apply_inflections(word, rules, locale = :en, count = nil)
     result = word.to_s.dup
 
-    return result if word.empty? \
-                       || inflections(locale).uncountables.uncountable?(result)
+    if word.empty? || inflections(locale).uncountables.uncountable?(result)
+      return result
+    end
 
     rules.each do |rule, replacement, range|
-      break if (range.nil? || range.include?(count)) \
-                                              && result.sub!(rule, replacement)
+      if (range.nil? || range.include?(count)) && result.sub!(rule, replacement)
+        break
+      end
     end
     result
   end

--- a/lib/inflector_extensions.rb
+++ b/lib/inflector_extensions.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class String
-  def pluralize(count = nil, locale = :en)
-    locale = count if count.is_a?(Symbol)
-
+  def pluralize(count: nil, locale: :en)
     if count == 1
       dup
     else

--- a/lib/inflector_extensions.rb
+++ b/lib/inflector_extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class String
   def pluralize(count = nil, locale = :en)
     locale = count if count.is_a?(Symbol)
@@ -38,11 +40,16 @@ module InflectionsExtensions
   end
 end
 
-module ActiveSupport::Inflector
-  extend self
-  extend InflectorExtensions
+module ActiveSupport
+  module Inflector
+    extend InflectorExtensions
+  end
 end
 
-class ActiveSupport::Inflector::Inflections
-  prepend InflectionsExtensions
+module ActiveSupport
+  module Inflector
+    class Inflections
+      prepend InflectionsExtensions
+    end
+  end
 end

--- a/lib/inflector_extensions.rb
+++ b/lib/inflector_extensions.rb
@@ -19,15 +19,12 @@ module InflectorExtensions
   def apply_inflections(word, rules, locale = :en, count = nil)
     result = word.to_s.dup
 
-    if word.empty? || inflections(locale).uncountables.uncountable?(result)
-      result
-    elsif count.nil?
-      rules.each { |(rule, replacement)| break if result.sub!(rule, replacement) }
-    else
-      rules.each do |(rule, replacement, range)|
-        break if range&.include?(count) && result.sub!(rule, replacement)
-        break if range.nil? && result.sub!(rule, replacement)
-      end
+    return result if word.empty? \
+                       || inflections(locale).uncountables.uncountable?(result)
+
+    rules.each do |rule, replacement, range|
+      break if (range.nil? || range.include?(count)) \
+                                              && result.sub!(rule, replacement)
     end
     result
   end

--- a/lib/inflector_extensions.rb
+++ b/lib/inflector_extensions.rb
@@ -1,0 +1,48 @@
+class String
+  def pluralize(count = nil, locale = :en)
+    locale = count if count.is_a?(Symbol)
+    if count == 1
+      dup
+    else
+      ActiveSupport::Inflector.pluralize(self, count, locale)
+    end
+  end
+end
+
+module InflectorExtensions
+  def pluralize(word, count = nil, locale = :en)
+    apply_inflections(word, inflections(locale).plurals, locale, count)
+  end
+
+  def apply_inflections(word, rules, locale = :en, count = nil)
+    result = word.to_s.dup
+
+    if word.empty? || inflections(locale).uncountables.uncountable?(result)
+      result
+    elsif count.nil?
+      rules.each { |(rule, replacement)| break if result.sub!(rule, replacement) }
+    else
+      rules.each do |(rule, replacement, range)|
+        break if range&.include?(count) && result.sub!(rule, replacement)
+        break if range.nil? && result.sub!(rule, replacement)
+      end
+    end
+    result
+  end
+end
+
+module InflectionsExtensions
+  def plural(rule, replacement, range = nil)
+    super(rule, replacement)
+    @plurals.first << range unless range.nil?
+  end
+end
+
+module ActiveSupport::Inflector
+  extend self
+  extend InflectorExtensions
+end
+
+class ActiveSupport::Inflector::Inflections
+  prepend InflectionsExtensions
+end

--- a/lib/inflector_extensions.rb
+++ b/lib/inflector_extensions.rb
@@ -3,6 +3,7 @@
 class String
   def pluralize(count = nil, locale = :en)
     locale = count if count.is_a?(Symbol)
+
     if count == 1
       dup
     else
@@ -19,7 +20,7 @@ module InflectorExtensions
   def apply_inflections(word, rules, locale = :en, count = nil)
     result = word.to_s.dup
 
-    if word.empty? || inflections(locale).uncountables.uncountable?(result)
+    if word.blank? || inflections(locale).uncountables.uncountable?(result)
       return result
     end
 

--- a/spec/lib/inflector_extensions_spec.rb
+++ b/spec/lib/inflector_extensions_spec.rb
@@ -1,82 +1,167 @@
 require 'rails_helper'
 
-RSpec.describe '#pluralize' do
-  context 'months' do
-    let(:months) do
-      {
-        1 => 'місяць',
-        2 => 'місяці',
-        3 => 'місяці',
-        4 => 'місяці',
-        5 => 'місяців',
-        6 => 'місяців',
-        7 => 'місяців',
-        8 => 'місяців',
-        9 => 'місяців',
-        10 => 'місяців',
-        11 => 'місяців',
-        0 => 'місяців'
-      }
+RSpec.describe String do
+  context 'with #pluralize' do
+    context 'with months' do
+      let(:months) do
+        {
+          1 => 'місяць',
+          2 => 'місяці',
+          3 => 'місяці',
+          4 => 'місяці',
+          5 => 'місяців',
+          6 => 'місяців',
+          7 => 'місяців',
+          8 => 'місяців',
+          9 => 'місяців',
+          10 => 'місяців',
+          11 => 'місяців',
+          0 => 'місяців'
+        }
+      end
+
+      it 'properly pluralizes all months' do
+        months.each do |count, expected|
+          expect('місяць'.pluralize(count, :uk)).to eq(expected)
+        end
+      end
     end
 
-    it 'properly pluralizes all months' do
-      months.each do |count, expected|
-        expect('місяць'.pluralize(count, :uk)).to eq(expected)
+    context 'with years' do
+      let(:years) do
+        {
+          0 => 'років',
+          1 => 'рік',
+          2 => 'роки'
+        }
+      end
+
+      it 'properly pluralizes all years' do
+        years.each do |count, expected|
+          expect('рік'.pluralize(count, :uk)).to eq(expected)
+        end
+      end
+    end
+
+    context 'with common cases with english locale' do
+      context 'with words that can be plural' do
+        it 'pluralizes properly without count parameter' do
+          expect('dog'.pluralize).to eq('dogs')
+          expect('cat'.pluralize).to eq('cats')
+          expect('octopus'.pluralize).to eq('octopi')
+          expect('buffalo'.pluralize).to eq('buffaloes')
+          expect('mouse'.pluralize).to eq('mice')
+        end
+
+        it 'pluralizes properly with count parameter' do
+          expect('dog'.pluralize(10)).to eq('dogs')
+          expect('cat'.pluralize(1)).to eq('cat')
+          expect('alias'.pluralize(123)).to eq('aliases')
+          expect('buffalo'.pluralize(1, :en)).to eq('buffalo')
+          expect('bus'.pluralize(0)).to eq('buses')
+        end
+
+        it 'pluralizes irregular words properly' do
+          expect('person'.pluralize(10)).to eq('people')
+          expect('man'.pluralize(1)).to eq('man')
+          expect('child'.pluralize(0)).to eq('children')
+          expect('zombie'.pluralize).to eq('zombies')
+          expect('sex'.pluralize(666)).to eq('sexes')
+        end
+      end
+
+      context 'with words that cannot be plural' do
+        it 'does not pluralize uncountable words' do
+          expect('equipment'.pluralize(10)).to eq('equipment')
+          expect('information'.pluralize).to eq('information')
+          expect('rice'.pluralize(0)).to eq('rice')
+          expect('money'.pluralize(1)).to eq('money')
+          expect('fish'.pluralize(666)).to eq('fish')
+        end
       end
     end
   end
+end
 
-  context 'years' do
-    let(:years) do
-      {
-        0 => 'років',
-        1 => 'рік',
-        2 => 'роки'
-      }
-    end
-
-    it 'properly pluralizes all years' do
-      years.each do |count, expected|
-        expect('рік'.pluralize(count, :uk)).to eq(expected)
-      end
+RSpec.describe ActiveSupport::Inflector do
+  context 'with #pluralize' do
+    it 'pluralizes properly' do
+      expect(ActiveSupport::Inflector.pluralize('місяць', 2, :uk)).to eq('місяці')
+      expect(ActiveSupport::Inflector.pluralize('рік', 0, :uk)).to eq('років')
+      expect(ActiveSupport::Inflector.pluralize('dog', locale = :en)).to eq('dogs')
+      expect(ActiveSupport::Inflector.pluralize('money', count = 15)).to eq('money')
+      expect(ActiveSupport::Inflector.pluralize('person', 2)).to eq('people')
     end
   end
 
-  context 'common cases with english locale' do
-    context 'words that can be plural' do
-      it 'pluralizes properly without count parameter' do
-        expect('dog'.pluralize).to eq('dogs')
-        expect('cat'.pluralize).to eq('cats')
-        expect('octopus'.pluralize).to eq('octopi')
-        expect('buffalo'.pluralize).to eq('buffaloes')
-        expect('mouse'.pluralize).to eq('mice')
-      end
-
-      it 'pluralizes properly with count parameter' do
-        expect('dog'.pluralize(10)).to eq('dogs')
-        expect('cat'.pluralize(1)).to eq('cat')
-        expect('alias'.pluralize(123)).to eq('aliases')
-        expect('buffalo'.pluralize(1, :en)).to eq('buffalo')
-        expect('bus'.pluralize(0)).to eq('buses')
-      end
-
-      it 'pluralizes irregular words properly' do
-        expect('person'.pluralize(10)).to eq('people')
-        expect('man'.pluralize(1)).to eq('man')
-        expect('child'.pluralize(0)).to eq('children')
-        expect('zombie'.pluralize).to eq('zombies')
-        expect('sex'.pluralize(666)).to eq('sexes')
-      end
+  context 'with #apply_inflections' do
+    let(:uk_rules) do
+      [
+        ['людина', 'людина', [1]],
+        ['людина', 'людини', [2, 3, 4]],
+        ['людина', 'людей', [0, 5, 6, 7, 8, 9, 10]],
+        ['кіт', 'коти']
+      ]
     end
 
-    context 'words that cannot be plural' do
-      it 'does not pluralize uncountable words' do
-        expect('equipment'.pluralize(10)).to eq('equipment')
-        expect('information'.pluralize).to eq('information')
-        expect('rice'.pluralize(0)).to eq('rice')
-        expect('money'.pluralize(1)).to eq('money')
-        expect('fish'.pluralize(666)).to eq('fish')
-      end
+    let(:en_rules) do
+      [
+        ['dog', 'dog', [1]],
+        ['dog', 'dogs', (2..100).to_a],
+        ['dog', 'other dogs', (100..110).to_a],
+        ['cat', 'cats']
+      ]
+    end
+
+    it 'applies properly plurals with ukrainian rules' do
+      expect(ActiveSupport::Inflector.apply_inflections('людина',
+                                                        uk_rules,
+                                                        locale = :uk,
+                                                        count = 1)).to eq('людина')
+      expect(ActiveSupport::Inflector.apply_inflections('людина',
+                                                        uk_rules,
+                                                        locale = :uk,
+                                                        count = 3)).to eq('людини')
+      expect(ActiveSupport::Inflector.apply_inflections('людина',
+                                                        uk_rules,
+                                                        locale = :uk,
+                                                        count = 9)).to eq('людей')
+      expect(ActiveSupport::Inflector.apply_inflections('кіт',
+                                                        uk_rules,
+                                                        locale = :uk)).to eq('коти')
+    end
+
+    it 'applies properly plurals with english rules' do
+      expect(ActiveSupport::Inflector.apply_inflections('dog',
+                                                        en_rules,
+                                                        locale = :en,
+                                                        count = 1)).to eq('dog')
+      expect(ActiveSupport::Inflector.apply_inflections('dog',
+                                                        en_rules,
+                                                        locale = :en,
+                                                        count = 99)).to eq('dogs')
+      expect(ActiveSupport::Inflector.apply_inflections('dog',
+                                                        en_rules,
+                                                        locale = :en,
+                                                        count = 101)).to eq('other dogs')
+      expect(ActiveSupport::Inflector.apply_inflections('cat',
+                                                        en_rules,
+                                                        locale = :en)).to eq('cats')
+    end
+  end
+end
+
+RSpec.describe ActiveSupport::Inflector::Inflections do
+  context 'with #plural' do
+    let(:uk_plurals) { ActiveSupport::Inflector.inflections(:uk).plurals }
+
+    after do
+      ActiveSupport::Inflector.inflections(:uk).plurals.shift
+    end
+
+    it 'runs properly' do
+      ActiveSupport::Inflector.inflections(:uk).plural('машина', 'машини', [2, 3, 4])
+      expect(uk_plurals.first).to eq(['машина', 'машини', [2, 3, 4]])
     end
   end
 end

--- a/spec/lib/inflector_extensions_spec.rb
+++ b/spec/lib/inflector_extensions_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe ActiveSupport::Inflector do
     it 'pluralizes properly' do
       expect(ActiveSupport::Inflector.pluralize('місяць', 2, :uk)).to eq('місяці')
       expect(ActiveSupport::Inflector.pluralize('рік', 0, :uk)).to eq('років')
-      expect(ActiveSupport::Inflector.pluralize('dog', locale = :en)).to eq('dogs')
-      expect(ActiveSupport::Inflector.pluralize('money', count = 15)).to eq('money')
+      expect(ActiveSupport::Inflector.pluralize('dog', :en)).to eq('dogs')
+      expect(ActiveSupport::Inflector.pluralize('money', 15)).to eq('money')
       expect(ActiveSupport::Inflector.pluralize('person', 2)).to eq('people')
     end
   end

--- a/spec/lib/inflector_extensions_spec.rb
+++ b/spec/lib/inflector_extensions_spec.rb
@@ -129,6 +129,10 @@ RSpec.describe ActiveSupport::Inflector do
       expect(ActiveSupport::Inflector.apply_inflections('кіт',
                                                         uk_rules,
                                                         locale = :uk)).to eq('коти')
+      expect(ActiveSupport::Inflector.apply_inflections('кіт',
+                                                        uk_rules,
+                                                        locale = :uk,
+                                                        count = 99)).to eq('коти')
     end
 
     it 'applies properly plurals with english rules' do
@@ -147,6 +151,34 @@ RSpec.describe ActiveSupport::Inflector do
       expect(ActiveSupport::Inflector.apply_inflections('cat',
                                                         en_rules,
                                                         locale = :en)).to eq('cats')
+      expect(ActiveSupport::Inflector.apply_inflections('cat',
+                                                        en_rules,
+                                                        locale = :en,
+                                                        count = 99)).to eq('cats')
+    end
+
+    it 'does not plural empty string' do
+      expect(ActiveSupport::Inflector.apply_inflections('',
+                                                        en_rules,
+                                                        locale = :en,
+                                                        count = 99)).to eq('')
+      expect(ActiveSupport::Inflector.apply_inflections('',
+                                                        en_rules,
+                                                        locale = :uk,
+                                                        count = 99)).to eq('')
+      expect(ActiveSupport::Inflector.apply_inflections('',
+                                                        en_rules,
+                                                        locale = :en)).to eq('')
+    end
+
+    it 'does not plural uncountable words' do
+      expect(ActiveSupport::Inflector.apply_inflections('equipment',
+                                                        en_rules,
+                                                        locale = :en,
+                                                        count = 99)).to eq('equipment')
+      expect(ActiveSupport::Inflector.apply_inflections('money',
+                                                        en_rules,
+                                                        locale = :en)).to eq('money')
     end
   end
 end

--- a/spec/lib/inflector_extensions_spec.rb
+++ b/spec/lib/inflector_extensions_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe String do
 
       it 'properly pluralizes all months' do
         months.each do |count, expected|
-          expect('місяць'.pluralize(count, :uk)).to eq(expected)
+          expect('місяць'.pluralize(count: count, locale: :uk)).to eq(expected)
         end
       end
     end
@@ -38,7 +38,7 @@ RSpec.describe String do
 
       it 'properly pluralizes all years' do
         years.each do |count, expected|
-          expect('рік'.pluralize(count, :uk)).to eq(expected)
+          expect('рік'.pluralize(count: count, locale: :uk)).to eq(expected)
         end
       end
     end
@@ -54,29 +54,29 @@ RSpec.describe String do
         end
 
         it 'pluralizes properly with count parameter' do
-          expect('dog'.pluralize(10)).to eq('dogs')
-          expect('cat'.pluralize(1)).to eq('cat')
-          expect('alias'.pluralize(123)).to eq('aliases')
-          expect('buffalo'.pluralize(1, :en)).to eq('buffalo')
-          expect('bus'.pluralize(0)).to eq('buses')
+          expect('dog'.pluralize(count: 10)).to eq('dogs')
+          expect('cat'.pluralize(count: 1)).to eq('cat')
+          expect('alias'.pluralize(count: 123)).to eq('aliases')
+          expect('buffalo'.pluralize(count: 1, locale: :en)).to eq('buffalo')
+          expect('bus'.pluralize(count: 0)).to eq('buses')
         end
 
         it 'pluralizes irregular words properly' do
-          expect('person'.pluralize(10)).to eq('people')
-          expect('man'.pluralize(1)).to eq('man')
-          expect('child'.pluralize(0)).to eq('children')
+          expect('person'.pluralize(count: 10)).to eq('people')
+          expect('man'.pluralize(count: 1)).to eq('man')
+          expect('child'.pluralize(count: 0)).to eq('children')
           expect('zombie'.pluralize).to eq('zombies')
-          expect('sex'.pluralize(666)).to eq('sexes')
+          expect('sex'.pluralize(count: 666)).to eq('sexes')
         end
       end
 
       context 'with words that cannot be plural' do
         it 'does not pluralize uncountable words' do
-          expect('equipment'.pluralize(10)).to eq('equipment')
+          expect('equipment'.pluralize(count: 10)).to eq('equipment')
           expect('information'.pluralize).to eq('information')
-          expect('rice'.pluralize(0)).to eq('rice')
-          expect('money'.pluralize(1)).to eq('money')
-          expect('fish'.pluralize(666)).to eq('fish')
+          expect('rice'.pluralize(count: 0)).to eq('rice')
+          expect('money'.pluralize(count: 1)).to eq('money')
+          expect('fish'.pluralize(count: 666)).to eq('fish')
         end
       end
     end

--- a/spec/lib/inflector_extensions_spec.rb
+++ b/spec/lib/inflector_extensions_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ActiveSupport::Inflector do
     it 'pluralizes properly' do
       expect(ActiveSupport::Inflector.pluralize('місяць', 2, :uk)).to eq('місяці')
       expect(ActiveSupport::Inflector.pluralize('рік', 0, :uk)).to eq('років')
-      expect(ActiveSupport::Inflector.pluralize('dog', :en)).to eq('dogs')
+      expect(ActiveSupport::Inflector.pluralize('dog')).to eq('dogs')
       expect(ActiveSupport::Inflector.pluralize('money', 15)).to eq('money')
       expect(ActiveSupport::Inflector.pluralize('person', 2)).to eq('people')
     end

--- a/spec/lib/inflector_extensions_spec.rb
+++ b/spec/lib/inflector_extensions_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe '#pluralize' do
+  context 'months' do
+    let(:months) do
+      {
+        1 => 'місяць',
+        2 => 'місяці',
+        3 => 'місяці',
+        4 => 'місяці',
+        5 => 'місяців',
+        6 => 'місяців',
+        7 => 'місяців',
+        8 => 'місяців',
+        9 => 'місяців',
+        10 => 'місяців',
+        11 => 'місяців',
+        0 => 'місяців'
+      }
+    end
+
+    it 'properly pluralizes all months' do
+      months.each do |count, expected|
+        expect('місяць'.pluralize(count, :uk)).to eq(expected)
+      end
+    end
+  end
+
+  context 'years' do
+    let(:years) do
+      {
+        0 => 'років',
+        1 => 'рік',
+        2 => 'роки'
+      }
+    end
+
+    it 'properly pluralizes all years' do
+      years.each do |count, expected|
+        expect('рік'.pluralize(count, :uk)).to eq(expected)
+      end
+    end
+  end
+
+  context 'common cases with english locale' do
+    context 'words that can be plural' do
+      it 'pluralizes properly without count parameter' do
+        expect('dog'.pluralize).to eq('dogs')
+        expect('cat'.pluralize).to eq('cats')
+        expect('octopus'.pluralize).to eq('octopi')
+        expect('buffalo'.pluralize).to eq('buffaloes')
+        expect('mouse'.pluralize).to eq('mice')
+      end
+
+      it 'pluralizes properly with count parameter' do
+        expect('dog'.pluralize(10)).to eq('dogs')
+        expect('cat'.pluralize(1)).to eq('cat')
+        expect('alias'.pluralize(123)).to eq('aliases')
+        expect('buffalo'.pluralize(1, :en)).to eq('buffalo')
+        expect('bus'.pluralize(0)).to eq('buses')
+      end
+
+      it 'pluralizes irregular words properly' do
+        expect('person'.pluralize(10)).to eq('people')
+        expect('man'.pluralize(1)).to eq('man')
+        expect('child'.pluralize(0)).to eq('children')
+        expect('zombie'.pluralize).to eq('zombies')
+        expect('sex'.pluralize(666)).to eq('sexes')
+      end
+    end
+
+    context 'words that cannot be plural' do
+      it 'does not pluralize uncountable words' do
+        expect('equipment'.pluralize(10)).to eq('equipment')
+        expect('information'.pluralize).to eq('information')
+        expect('rice'.pluralize(0)).to eq('rice')
+        expect('money'.pluralize(1)).to eq('money')
+        expect('fish'.pluralize(666)).to eq('fish')
+      end
+    end
+  end
+end


### PR DESCRIPTION
dev
## JIRA

* [ZER-185](https://jira.softserve.academy/browse/ZER-185)


## Code reviewers

- [ ] @loqimean 


## Summary of issue

As a user, I want to see numbers with words in drop-down lists so that the choice will be easier for understanding.

Acceptance criteria:

GIVEN the user wants to choose the child’s age on the calculator page
WHEN he/she is clicking on ‘years’ and ‘months’
THEN ‘0 years; 1 year; 2 years’ is displayed for ‘years’
AND ‘1 month; 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 months’ is displayed for ‘months’
See the exact texts in the file: https://docs.google.com/document/d/1ezwQR3gtY06rKcotLiFJE_XJBqnw5I1RuzTHiywW4eU/edit

English:
![image](https://user-images.githubusercontent.com/109829102/200040400-7ab2d6ca-8a06-4920-8e7e-8f247349263d.png)

Ukrainian:
![image](https://user-images.githubusercontent.com/109829102/200040496-1941b263-b00e-4553-8f7d-a2ee7c74bc45.png)


## Summary of change

English:
Added words 'year' and 'years' for the corresponding values in years dropdown. Similar for months dropdown

![image](https://user-images.githubusercontent.com/109829102/200041622-80b90cab-9bd3-490d-9b53-3e99f1aa2913.png)

![image](https://user-images.githubusercontent.com/109829102/200039801-3b2e8184-39ee-4281-99c3-76af802b3bd9.png)

Ukrainian:
Added words 'років', 'рік', 'роки' for the corresponding values in years dropdown. Similar for months dropdown

![image](https://user-images.githubusercontent.com/109829102/200041560-3c156ba0-1998-4460-8207-08304911066e.png)

![image](https://user-images.githubusercontent.com/109829102/200040077-1cf3260a-e980-4844-80c0-a0e00681cea5.png)

Additional changes:
Set attribute 'hidden' for values above '0 years' or '0 months' values

## Testing approach

ToDo

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
