### PR TITLE
Zer 183 results display block values placing mobile version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,4 +499,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.3.24
+   2.3.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,4 +499,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.3.11
+   2.3.24

--- a/app/javascript/css/calculator.css.scss
+++ b/app/javascript/css/calculator.css.scss
@@ -147,7 +147,7 @@
   }
 }
 
-@media screen and (max-width: $xs) {
+@media screen and (max-width: $md) {
   .logo-zerowaste img {
     width: 100%;
   }

--- a/app/javascript/css/calculator.css.scss
+++ b/app/javascript/css/calculator.css.scss
@@ -118,7 +118,7 @@
   margin-left: 50px;
   margin-top: 45px;
   a {
-    color:$color;
+    color: $color;
     background-color: transparent;
     text-decoration: none;
   }
@@ -129,9 +129,9 @@
     text-align: left;
     margin-left: 30px;
     a {
-        color: $success;
-        background-color: transparent;
-        text-decoration: none;
+      color: $success;
+      background-color: transparent;
+      text-decoration: none;
     }
     a:hover {
       color: #256d36;
@@ -151,6 +151,7 @@
   .logo-zerowaste img {
     width: 100%;
   }
+
   .logo-zerowaste {
     width: 140px;
   }

--- a/app/javascript/css/contact_us.css.scss
+++ b/app/javascript/css/contact_us.css.scss
@@ -1,30 +1,24 @@
 .contact-form .msg,
-.contact-form .email
-{
+.contact-form .email {
   margin-bottom: 1rem;
 }
 
-.contact-form textarea
-{
+.contact-form textarea {
   border: 2px solid $gray;
 }
 
-.text
-{
+.text {
   margin-bottom: 0.5rem;
-
 }
 
-.contact-info
-{
+.contact-info {
   color: #000;
   background-color: $color;
   width: 40%;
   border-radius: 10px;
   text-align: center;
   min-width: max-content;
-  & a
-  {
+  & a {
     color: #000;
     border-bottom: solid #212529 2px;
     padding: 1%;

--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -394,7 +394,7 @@ body.admin {
   }
 }
 
-@media screen and (max-width: $sm) {
+@media screen and (max-width: $md) {
   .tab {
     display: none;
   }

--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -227,7 +227,7 @@ div.calculation-results {
   border-radius: 6px;
 }
 
-.row-break {
+.row_break {
   display: none;
 }
 
@@ -427,7 +427,7 @@ body.admin {
     padding: 10px;
   }
 
-  .row-break {
+  .row_break {
     display: block;
   }
 }
@@ -442,7 +442,7 @@ body.admin {
     width: 750px;
   }
 
-  .row-break {
+  .row_break {
     display: block;
   }
 

--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -39,7 +39,6 @@ a {
   flex-wrap: wrap;
   align-items: center;
   border-bottom: 2px solid $gray;
-
 }
 
 div.jumbotron {
@@ -79,7 +78,7 @@ div.jumbotron {
   max-width: 420px;
   margin: 20px auto;
 
-  &> :last-of-type {
+  & > :last-of-type {
     & img {
       margin-right: 10px;
     }
@@ -228,7 +227,7 @@ div.calculation-results {
   border-radius: 6px;
 }
 
-.break-calculation-results-in-column{
+.break-calculation-results-in-column {
   display: none;
 }
 
@@ -256,7 +255,6 @@ div.calculation-results {
 
   p {
     font-size: 24px;
-
   }
 
   &:last-child {
@@ -297,9 +295,8 @@ body.admin {
 }
 
 .admin-table {
-
-  .admin-table-header>*,
-  .admin-table-body>* {
+  .admin-table-header > *,
+  .admin-table-body > * {
     display: flex;
   }
 
@@ -322,7 +319,7 @@ body.admin {
     }
 
     .admin-table-body {
-      &>* {
+      & > * {
         align-items: center;
       }
 
@@ -351,21 +348,24 @@ body.admin {
   .tab {
     display: none;
   }
+
   .filter_block {
     width: auto;
   }
 
   div.jumbotron,
   div.container {
-    max-width: 350px ;
+    max-width: 350px;
     margin-right: auto;
     margin-left: 15px;
 
     padding-left: 0px;
   }
+
   .calculation-results span {
     width: 410px;
   }
+
   .page-header {
     width: auto;
     margin-right: 15px;
@@ -377,6 +377,7 @@ body.admin {
   .donate-btn a {
     font-size: 12px;
   }
+
   .main-btns {
     max-width: 320px;
 
@@ -402,6 +403,7 @@ body.admin {
   .tab {
     display: none;
   }
+
   .func-btns {
     display: flex;
     flex-direction: column;
@@ -411,17 +413,21 @@ body.admin {
     padding-bottom: initial;
     width: fit-content;
   }
+
   .page-header {
     width: 510px;
   }
+
   .calculation-results,
   .jumbotron {
     width: 510px;
   }
+
   .donate-btn a {
     padding: 10px;
   }
-  .break-calculation-results-in-column{
+
+  .break-calculation-results-in-column {
     display: block;
   }
 }
@@ -430,13 +436,16 @@ body.admin {
   .page-header {
     width: 750px;
   }
+
   .calculation-results,
   .jumbotron {
     width: 750px;
   }
-  .break-calculation-results-in-column{
+
+  .break-calculation-results-in-column {
     display: block;
   }
+
   .donate-btn a {
     padding: 10px;
   }

--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -228,6 +228,10 @@ div.calculation-results {
   border-radius: 6px;
 }
 
+.break-calculation-results-in-column{
+  display: none;
+}
+
 .result-card {
   font-size: 14px;
   text-align: center;
@@ -394,7 +398,7 @@ body.admin {
   }
 }
 
-@media screen and (max-width: $md) {
+@media screen and (max-width: $sm) {
   .tab {
     display: none;
   }
@@ -413,6 +417,25 @@ body.admin {
   .calculation-results,
   .jumbotron {
     width: 510px;
+  }
+  .donate-btn a {
+    padding: 10px;
+  }
+  .break-calculation-results-in-column{
+    display: block;
+  }
+}
+
+@media screen and (max-width: $md) and (min-width: $sm) {
+  .page-header {
+    width: 750px;
+  }
+  .calculation-results,
+  .jumbotron {
+    width: 750px;
+  }
+  .break-calculation-results-in-column{
+    display: block;
   }
   .donate-btn a {
     padding: 10px;

--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -227,7 +227,7 @@ div.calculation-results {
   border-radius: 6px;
 }
 
-.break-calculation-results-in-column {
+.row-break {
   display: none;
 }
 
@@ -427,7 +427,7 @@ body.admin {
     padding: 10px;
   }
 
-  .break-calculation-results-in-column {
+  .row-break {
     display: block;
   }
 }
@@ -442,7 +442,7 @@ body.admin {
     width: 750px;
   }
 
-  .break-calculation-results-in-column {
+  .row-break {
     display: block;
   }
 

--- a/app/javascript/css/message.css.scss
+++ b/app/javascript/css/message.css.scss
@@ -1,25 +1,21 @@
 .contact-form .msg,
 .contact-form .email,
-.contact-form .title
-{
-  margin-bottom: .5rem;
+.contact-form .title {
+  margin-bottom: 0.5rem;
 }
 
-.contact-form textarea
-{
+.contact-form textarea {
   border: 2px solid $gray;
 }
 
-.contact-info
-{
+.contact-info {
   color: #000;
   background-color: $color;
   width: 40%;
   border-radius: 10px;
   text-align: center;
   min-width: max-content;
-  & a
-  {
+  & a {
     color: #000;
     border-bottom: solid #212529 2px;
     padding: 1%;

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -3,8 +3,9 @@ $color: #fff;
 $error: #9e1503;
 $gray: #8D8D8D;
 
-$xs: 575.98px;
-$sm: 767.98px;
+$xs: 576px;
+$sm: 768px;
+$sm: 1024px;
 
 @import "~bootstrap/scss/bootstrap";
 @import "../css/main.css.scss";

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -23,7 +23,7 @@ $sm: 767.98px;
   font-style: normal;
   font-display: swap;
 }
-  
+
 /*Mxn*/
 @mixin transform($transforms) {
   -webkit-transform: $transforms;

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -5,7 +5,7 @@ $gray: #8D8D8D;
 
 $xs: 576px;
 $sm: 768px;
-$sm: 1024px;
+$md: 1024px;
 
 @import "~bootstrap/scss/bootstrap";
 @import "../css/main.css.scss";

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -63,7 +63,7 @@
         - elsif I18n.locale == :uk
             #localized_uk_to_be_used_diapers_amount
               | підгузків ви ще використаєте
-    .w-100.row-break
+    .w-100.row_break
     .col-sm.result-card
       .img-border
         = image_pack_tag "money_spent.png", class:"rounded"

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -63,7 +63,7 @@
         - elsif I18n.locale == :uk
             #localized_uk_to_be_used_diapers_amount
               | підгузків ви ще використаєте
-    .w-100.break-calculation-results-in-column
+    .w-100.row-break
     .col-sm.result-card
       .img-border
         = image_pack_tag "money_spent.png", class:"rounded"

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -63,6 +63,7 @@
         - elsif I18n.locale == :uk
             #localized_uk_to_be_used_diapers_amount
               | підгузків ви ще використаєте
+    .w-100.break-calculation-results-in-column
     .col-sm.result-card
       .img-border
         = image_pack_tag "money_spent.png", class:"rounded"


### PR DESCRIPTION
dev
## JIRA

* [ZER-183](https://jira.softserve.academy/browse/ZER-183)


## Code reviewers

- [x] @loqimean 
- [x] @VasylenchukMischa 

## Summary of issue

The values are displayed in the result display block as "3 above, 1 below" (see screenshot).
![image](https://user-images.githubusercontent.com/70696653/200052510-a8510489-09f0-4dd7-b295-aa4ecd4092f5.png)

This was coused by flex-wrap in desktop version. When screen exceeded 768 it was counted as desktop, but there was not enought space for "4 in a row". And that why flex-wrap was displaysing "3 above, 1 below".

## Summary of change

1.  const values was rounded and 'md' was added for tablet version in `application.scss`:
```
$xs: 576px;
$sm: 768px;
$md: 1024px;
```
2. add break for results in `calculator.html.slim`
added row: `.w-100.row_break`

```
.row.row-l
    .col-sm.result-card
      ...
    .col-sm.result-card
      ...
    .w-100.row_break
    .col-sm.result-card
      ...
    .col-sm.result-card
      ...
```

3. add css for this break in 'main.css.scss'
 
```
 .row_break{
  display: none;
}
```

4. add break display for mobile in `main.css.scss`

```
@media screen and (max-width: $sm) {
  ...
  .row_break{
    display: block;
  }
}
```

5. add tablet version $md: 1024px; (tablet) in `main.css.scss`:

```
@media screen and (max-width: $md) and (min-width: $sm) {
  .page-header {
    width: 750px;
  }
  .calculation-results,
  .jumbotron {
    width: 750px;
  }
  .row_break{
    display: block;
  }
  .donate-btn a {
    padding: 10px;
  }
}
```

6. **Full CSS formating fix**
https://github.com/ita-social-projects/ZeroWaste/pull/280/commits/f98555726eb682bff49a54e84f28ec73fee04d9f

7. Demonstration of adaptability:

https://user-images.githubusercontent.com/70696653/200472452-3c885add-c99e-4e44-8666-dcf4610fc84e.mp4





## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
