### PR TITLE
ZER-186-Fix-the-background-for-mobile-version 

### DIFF
--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -366,11 +366,8 @@ body.admin {
   }
 
   .page-header {
-    width: auto;
-    margin-right: 15px;
-    margin-left: 15px;
     display: flex;
-    justify-content: flex-start;
+    justify-content: space-between;
   }
 
   .donate-btn a {
@@ -413,10 +410,6 @@ body.admin {
     width: fit-content;
   }
 
-  .page-header {
-    width: 510px;
-  }
-
   .calculation-results,
   .jumbotron {
     width: 510px;
@@ -447,5 +440,13 @@ body.admin {
 
   .donate-btn a {
     padding: 10px;
+  }
+}
+
+@media screen and (max-width: $md) and (min-width: $xs) {
+  .page-header {
+    width: auto;
+    margin-right: 15px;
+    margin-left: 15px;
   }
 }

--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -446,7 +446,7 @@ body.admin {
 @media screen and (max-width: $md) and (min-width: $xs) {
   .page-header {
     width: auto;
-    margin-right: 15px;
-    margin-left: 15px;
+    margin-right: 16px;
+    margin-left: 16px;
   }
 }


### PR DESCRIPTION
dev

[ZER-186](https://jira.softserve.academy/browse/ZER-186)

## Code reviewers

- [ ] @loqimean 

## Summary of issue

![image](https://user-images.githubusercontent.com/70696653/203547269-048dec35-4b7a-4b6f-bde8-e01305744ef4.png)

The width of the header in the mobile version was 510 pixels, which led to incorrect display

## Summary of change

1.  removed to fix a bug.
```
  .page-header {
    width: 510px;
  }
```
2. changed for the correct distribution of buttons on the header in mobile mode.

![image](https://user-images.githubusercontent.com/70696653/203547445-8cc0ce88-e697-486d-b6b0-21fa09fb79d9.png)
  
4. added new @media that generalizes header properties for phone, tablet screens to avoid code duplication.

```
@media screen and (max-width: $md) and (min-width: $xs) {
  .page-header {
    width: auto;
    margin-right: 15px;
    margin-left: 15px;
  }
}
```

5. the minimum width of the correct display of the main page is now at the mark of 342 pixels.

Screenshot confirming the changes:
![image](https://user-images.githubusercontent.com/70696653/203122979-217c7f72-1a4d-4189-a1ea-08bf6b6dbdaa.png)


## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
