### PR TITLE
ZER-188 replace cross button with back button in calculator

### DIFF
--- a/app/assets/images/arrow_left.svg
+++ b/app/assets/images/arrow_left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#00A8C6" class="bi bi-arrow-left" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z" fill="#8fba3b"/>
+</svg>

--- a/app/assets/stylesheets/pages/calculator.scss
+++ b/app/assets/stylesheets/pages/calculator.scss
@@ -29,19 +29,35 @@
   font-weight: 400;
   color: #666666;
   position: relative;
-  top: 17px;
+  top: 16px;
   left: 0px;
   margin-bottom: 0px;
 }
 
-.calculator__cross__space {
+.back_button_link {
+  display: block;
+}
+
+.back_button {
   position: absolute;
-  top: 8px;
-  right: 16px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 34px 18px 16px;
+}
+
+.calculator__back__label {
+  font-size: 14px;
+  font-weight: 300;
+  color: $success;
+}
+
+.back_button:hover .calculator__back__label {
+  text-decoration: underline;
 }
 
 .form {
-  padding-left: 15px;
+  padding-left: 16px;
 }
 
 .row-l {
@@ -152,7 +168,7 @@
 
 .logo-zerowaste img {
   width: 100%;
-  border-radius: 5px;
+  border-radius: 4px;
 }
 
 .description-btn {

--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -1,6 +1,9 @@
 .jumbotron.jumbotron-fluid.position-relative.rounded
-  a.rounded.calculator__cross__space href=root_path
-    = image_tag "close.svg", height: 40, class:"z-1"
+  a.back_button_link.rounded.calculator__cross__space href=root_path
+    .back_button
+      = image_tag "arrow_left.svg", height: 26, class:"z-1 position-relative"
+      .calculator__back__label
+        = t '.back_button_label'
   .d-flex.justify-content-around.flex-wrap.calculator_wrap
     = simple_form_for(:child, url: "#", html: { class: "simple_form_calculator",
                                                data:{ controller: "input-child-info",

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -33,6 +33,7 @@ en:
   uk: "Українська"
   calculators:
     calculator:
+      back_button_label: "back"
       diaper: "diaper"
       form_description: "Child’s age:"
       form_price: "Price category"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -2,6 +2,7 @@ uk:
   en: English
   calculators:
     calculator:
+      back_button_label: "назад"
       diaper: "підгузок"
       form_description: "Вік дитини:"
       form_price: "Цінова категорія"


### PR DESCRIPTION
dev
## JIRA

* [ZER-188](https://jira.softserve.academy/browse/ZER-188)

## Code reviewers

- [ ] @loqimean 
- [ ] @VasylenchukMischa

## Summary of issue

Expected result:
- To return from the calculator to the main page, there is a button with a "back" icon in the calculator.
- There is a "back" label near the button.
- The button is located on the left.
- This button should be on top and occupy all width of its container.

Actual result:
- To return from the calculator to the main page, there is a button with a "cross" icon in the calculator.
- There is no "back" label near the button.
- The button is located on the right.
- This button is near the "Child's age".

![image](https://user-images.githubusercontent.com/85323700/205127714-1e0e24d3-14e7-4a89-85c1-d64f8cce228d.png)

## Summary of change

1. The cross button was replaced with the back button.
2. Ukrainian and English localization for the back button added.
3. CSS and HTML of some of its parent elements were changed to have more suitable spacing.
4. Some odd CSS values have been replaced with even values to conform to standards.

![image](https://user-images.githubusercontent.com/85323700/205129720-37894c65-2bb0-4a65-bd8f-530178296102.png)


## Testing approach

ToDo

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked the new feature as logged in and logged out the user if needed
- [ ]  PR meets all conventions