### PR TITLE
ZER-Correction buttons on the right side

### DIFF
--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -426,6 +426,6 @@ body.admin {
 
 @media screen and (max-width: 768px) {
   .donate-btn a {
-    margin-bottom: 0.4em;
+    margin-bottom: 0.4rem;
   }
 }

--- a/app/javascript/css/main.css.scss
+++ b/app/javascript/css/main.css.scss
@@ -53,7 +53,7 @@ div.jumbotron {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-end;
   width: 315px;
   font-family: "Nunito", sans-serif;
 }
@@ -96,7 +96,6 @@ div.jumbotron {
   letter-spacing: 2px;
   text-transform: uppercase;
   font-family: "Nunito", sans-serif;
-  margin-bottom: 0.2em;
 
   a {
     border: 2px solid $gray;
@@ -411,10 +410,6 @@ body.admin {
   .row_break {
     display: block;
   }
-
-  .donate-btn a {
-    padding: 10px;
-  }
 }
 
 @media screen and (max-width: $md) and (min-width: $xs) {
@@ -426,5 +421,11 @@ body.admin {
   .calculation-results,
   .jumbotron {
     width: 96%;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .donate-btn a {
+    margin-bottom: 0.4em;
   }
 }


### PR DESCRIPTION
dev
## GitHub Board

* [ZeroWaste #313](https://github.com/orgs/ita-social-projects/projects/25/views/1)


## Code reviewers

- [ ] @loqimean 
- [ ] @VasylenchukMischa 

## Summary of issue

The "Support" button and the language selection button are aligned with the blocks on the right edge
![image](https://user-images.githubusercontent.com/106908913/210236540-b6695c5a-d20c-4895-a038-0ff72d19ebf2.png)


## Summary of change
![image](https://user-images.githubusercontent.com/106908913/210236757-d8573b20-4ce6-42f0-b902-710e1152ce07.png)
![image](https://user-images.githubusercontent.com/106908913/210236650-7d866cc2-eee1-433b-97d6-3fd4d6cc1c56.png)
![image](https://user-images.githubusercontent.com/106908913/210236671-29b77a11-9d64-47d9-a3b8-9e2f4ed80a9b.png)

## Testing approach

ToDo

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
