### PR TITLE
Changed order of the icons on calculators page

### DIFF
--- a/app/views/calculators/calculator.html.slim
+++ b/app/views/calculators/calculator.html.slim
@@ -50,13 +50,6 @@
   .row.row-l
     .col-sm.result-card
       .img-border
-        = image_pack_tag "diapers_bought.png", class:"rounded"
-      span
-        p [data-results-target="diapersUsed"] 0
-        .[data-results-target="UsedDiapersAmount"]
-          = "#{t(".diaper").pluralize(count: 0, locale: I18n.locale)} #{t('.bought_diapers')}"
-    .col-sm.result-card
-      .img-border
         = image_pack_tag "diapers_to_buy.png", class:"rounded"
       span
         p [data-results-target="diapersToBeUsed"] 0
@@ -65,16 +58,23 @@
     .w-100.row_break
     .col-sm.result-card
       .img-border
-        = image_pack_tag "money_spent.png", class:"rounded"
+        = image_pack_tag "diapers_bought.png", class:"rounded"
       span
-        p [data-results-target="moneySpent"] 0
-        = t '.money_spent'
+        p [data-results-target="diapersUsed"] 0
+        .[data-results-target="UsedDiapersAmount"]
+          = "#{t(".diaper").pluralize(count: 0, locale: I18n.locale)} #{t('.bought_diapers')}"
     .col-sm.result-card
       .img-border
         = image_pack_tag "money_to_spent.png", class:"rounded"
       span
         p [data-results-target="moneyWillBeSpent"] 0
         = t '.money_will_be_spent'
+    .col-sm.result-card
+      .img-border
+        = image_pack_tag "money_spent.png", class:"rounded"
+      span
+        p [data-results-target="moneySpent"] 0
+        = t '.money_spent'    
 
 .container.calculation-results
   .row


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @loqimean 
- [ ] @VasylenchukMischa  

### Second Level Review

- [ ] @loqimean 
- [ ] @VasylenchukMischa  

## Summary of issue

Correct order for icons (from right to the left):

Diaper to be used in the future
Diapers already used
UAH yet to be spent on diapers
UAH already spent on diapers
![image](https://user-images.githubusercontent.com/94442918/219945172-89ec6a40-44de-4b00-9580-759da99efb6b.png)


## Summary of change

When visiting calculators page icons are ordered as:
Diaper to be used in the future
Diapers already used
UAH yet to be spent on diapers
UAH already spent on diapers

![image](https://user-images.githubusercontent.com/94442918/219945194-aabaf99a-99e1-4709-9ed9-331ad31351c4.png)

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
