### PR TITLE
Zer 344 correct the algorithm of drop down lists for years and months

### DIFF
--- a/app/javascript/controllers/input_child_info_controller.js
+++ b/app/javascript/controllers/input_child_info_controller.js
@@ -23,32 +23,32 @@ export default class extends Controller {
 
   yearChanged(e) {
 
-    // Якщо значення року не пусте, то скидаємо значення місяця на null, інакше на порожнє рядок
+    // If the year value is not empty, then reset the month value to null, otherwise to an empty string
     if (e.target.value !== "") {
       this.monthTarget.value = null;
     } else {
       this.monthTarget.value = "";
     }
 
-    // Очистка старих опцій зі списку вибору місяця
+    // Clear old options from the month selection list
     this.monthTarget.innerHTML = "";
 
-    // Визначення кількості опцій для місяців
+    // Determining the number of options for months
     const amount_options = e.target.value == 2 ? 6 : 11;
 
-    // Збереження попереднього значення місяця перед оновленням
+    // Save the previous month value before updating
     const previous_month_value = this.monthTarget.value;
 
-    // Якщо місяць не було вибрано до оновлення, додаємо порожню опцію на початок списку
+    // If the month was not selected before the update, add an empty option to the top of the list
     if (this.monthTarget && !previous_month_value) {
       this.monthTarget.appendChild(this.getNillOption(previous_month_value));
     }
 
-    // Додавання нових опцій до списку вибору місяця
+    // Adding new options to the month selection list
     for (let i = 0; i <= amount_options; i++) {
       this.monthTarget.appendChild(this.getBasicOption(i));
 
-      // Якщо попереднє значення місяця збережене, встановлюємо його як вибране значення
+      // If the previous month value is saved, set it as the selected value
       if (i == previous_month_value && previous_month_value) {
         this.monthTarget.value = i;
       }

--- a/app/javascript/controllers/input_child_info_controller.js
+++ b/app/javascript/controllers/input_child_info_controller.js
@@ -24,33 +24,30 @@ export default class extends Controller {
   yearChanged(e) {
 
     // If the year value is not empty, then reset the month value to null, otherwise to an empty string
-    if (e.target.value !== "") {
-      this.monthTarget.value = null;
-    } else {
-      this.monthTarget.value = "";
-    }
+    (e.target.value !== '')
+    this.monthTarget.value = null;
 
     // Clear old options from the month selection list
-    this.monthTarget.innerHTML = "";
+    this.monthTarget.innerHTML = '';
 
     // Determining the number of options for months
-    const amount_options = e.target.value == 2 ? 6 : 11;
+    const amountOptions = e.target.value == 2 ? 6 : 11;
 
     // Save the previous month value before updating
-    const previous_month_value = this.monthTarget.value;
+    const previousMonthValue = this.monthTarget.value;
 
     // If the month was not selected before the update, add an empty option to the top of the list
-    if (this.monthTarget && !previous_month_value) {
-      this.monthTarget.appendChild(this.getNillOption(previous_month_value));
+    if (this.monthTarget && !previousMonthValue) {
+      this.monthTarget.appendChild(this.getNillOption(previousMonthValue));
     }
 
     // Adding new options to the month selection list
-    for (let i = 0; i <= amount_options; i++) {
-      this.monthTarget.appendChild(this.getBasicOption(i));
+    for (let monthIndex = 0; monthIndex <= amountOptions; monthIndex++) {
+      this.monthTarget.appendChild(this.getBasicOption(monthIndex));
 
       // If the previous month value is saved, set it as the selected value
-      if (i == previous_month_value && previous_month_value) {
-        this.monthTarget.value = i;
+      if (monthIndex == previousMonthValue && previousMonthValue) {
+        this.monthTarget.value = monthIndex;
       }
     }
   }

--- a/app/javascript/controllers/input_child_info_controller.js
+++ b/app/javascript/controllers/input_child_info_controller.js
@@ -23,10 +23,6 @@ export default class extends Controller {
 
   yearChanged(e) {
 
-    // If the year value is not empty, then reset the month value to null, otherwise to an empty string
-    (e.target.value !== '')
-    this.monthTarget.value = null;
-
     // Clear old options from the month selection list
     this.monthTarget.innerHTML = '';
 

--- a/app/javascript/controllers/input_child_info_controller.js
+++ b/app/javascript/controllers/input_child_info_controller.js
@@ -22,21 +22,36 @@ export default class extends Controller {
   }
 
   yearChanged(e) {
-    //generate 6 options for month if chosen year = 2, else generate 11 options
-    let amount_options = e.target.value == 2 ? 5 : 11;
 
-    let previous_month_value = this.monthTarget.value;
+    // Якщо значення року не пусте, то скидаємо значення місяця на null, інакше на порожнє рядок
+    if (e.target.value !== "") {
+      this.monthTarget.value = null;
+    } else {
+      this.monthTarget.value = "";
+    }
 
+    // Очистка старих опцій зі списку вибору місяця
     this.monthTarget.innerHTML = "";
 
-    if (previous_month_value == "")
-      this.monthTarget.appendChild(this.getNillOption(previous_month_value));
+    // Визначення кількості опцій для місяців
+    const amount_options = e.target.value == 2 ? 6 : 11;
 
+    // Збереження попереднього значення місяця перед оновленням
+    const previous_month_value = this.monthTarget.value;
+
+    // Якщо місяць не було вибрано до оновлення, додаємо порожню опцію на початок списку
+    if (this.monthTarget && !previous_month_value) {
+      this.monthTarget.appendChild(this.getNillOption(previous_month_value));
+    }
+
+    // Додавання нових опцій до списку вибору місяця
     for (let i = 0; i <= amount_options; i++) {
       this.monthTarget.appendChild(this.getBasicOption(i));
 
-      if (i == previous_month_value && previous_month_value != "")
+      // Якщо попереднє значення місяця збережене, встановлюємо його як вибране значення
+      if (i == previous_month_value && previous_month_value) {
         this.monthTarget.value = i;
+      }
     }
   }
 

--- a/spec/features/reset_month_value_spec.rb
+++ b/spec/features/reset_month_value_spec.rb
@@ -2,20 +2,20 @@
 
 require "rails_helper"
 
-RSpec.describe "Year changed", request: true do
-  it "Reset month value when year changes" do
+RSpec.describe "Year changed", type: :feature do
+  let(:year_select) { find("#child_years") }
+  let(:month_select) { find("#child_months") }
+
+  it "resets month value when year changes" do
     visit calculator_path
 
-    year_select = find("#child_years")
-    month_select = find("#child_months")
-
     year_select.select("0")
-    expect(month_select.value).to eq ""
+    expect(month_select.value).to eq("")
 
     year_select.select("1")
-    expect(month_select.value).to eq ""
+    expect(month_select.value).to eq("")
 
     year_select.select("2")
-    expect(month_select.value).to eq ""
+    expect(month_select.value).to eq("")
   end
 end

--- a/spec/features/reset_month_value_spec.rb
+++ b/spec/features/reset_month_value_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Year changed", request: true do
+  it "Reset month value when year changes" do
+    visit calculator_path
+
+    year_select = find("#child_years")
+    month_select = find("#child_months")
+
+    year_select.select("0")
+    expect(month_select.value).to eq ""
+
+    year_select.select("1")
+    expect(month_select.value).to eq ""
+
+    year_select.select("2")
+    expect(month_select.value).to eq ""
+  end
+end


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

correct the algorithm of drop-down lists for years and months, after changing the number for years, the last chosen months should be dropped.

## Summary of change

- after changing the input_child_info_controller.js file, the algorithm started to drop the month when the year changes.
- created the file reset_month_value_spec.rb to test this change in the algorithm

## Testing approach

Capybara test

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
