### PR TITLE
closes #558 fix wrong error message

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -16,8 +16,7 @@ class SiteSetting < ApplicationRecord
   validates :title, length: { minimum: 3, maximum: 30 }, if: -> { title.present? }
   validates :favicon, attached: true,
                       content_type: [:png, :jpg, :jpeg, :ico],
-                      size: { less_than: 500.kilobytes,
-                              message: I18n.t("account.site_settings.validations.size") }
+                      size: { less_than: 500.kilobytes }
 
   after_initialize :set_default_favicon
 

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -73,7 +73,10 @@ RSpec.describe SiteSetting, type: :model do
 
       it "is not valid" do
         is_expected.not_to be_valid
-        expect(subject.errors.messages[:favicon]).to include(I18n.t("account.site_settings.validations.size"))
+        expect(subject.errors.messages[:favicon]).to include(
+          I18n.t("errors.messages.file_size_out_of_range", 
+            file_size: "#{(invalid_favicon_size / 1024)} KB")
+        )
       end
     end
   end

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -75,8 +75,7 @@ RSpec.describe SiteSetting, type: :model do
         is_expected.not_to be_valid
         expect(subject.errors.messages[:favicon]).to include(
           I18n.t("errors.messages.file_size_out_of_range",
-                 file_size: "#{invalid_favicon_size / 1024} KB"
-                )
+                 file_size: "#{invalid_favicon_size / 1024} KB")
         )
       end
     end

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -74,8 +74,9 @@ RSpec.describe SiteSetting, type: :model do
       it "is not valid" do
         is_expected.not_to be_valid
         expect(subject.errors.messages[:favicon]).to include(
-          I18n.t("errors.messages.file_size_out_of_range", 
-            file_size: "#{(invalid_favicon_size / 1024)} KB")
+          I18n.t("errors.messages.file_size_out_of_range",
+                 file_size: "#{invalid_favicon_size / 1024} KB"
+                )
         )
       end
     end


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #558](https://github.com/orgs/ita-social-projects/projects/25/views/1?pane=issue&itemId=44753012)


## Code reviewers

- @loqimean

## Summary of issue

Wrong error message in Site Settings view if Admin chose a Favicon file more than 500K.

## Summary of change

Was a wrong message: "Favicon Translation missing: en.account.site_settings.validations.size"

<img width="1311" alt="Screenshot 2023-11-16 at 00 29 59" src="https://github.com/ita-social-projects/ZeroWaste/assets/35365419/1bfa585d-5b91-4c57-976e-dd52407d8903">


Is an example of the correct message: "Favicon has size 650 KB that is not between required range"

<img width="1311" alt="Screenshot 2023-11-16 at 00 29 29" src="https://github.com/ita-social-projects/ZeroWaste/assets/35365419/a4e1c8c6-6085-4334-b5ee-01fc6163180b">

This PR closes #558 issue.
