### PR TITLE
453 calculator page images size

### DIFF
--- a/app/assets/stylesheets/pages/main.scss
+++ b/app/assets/stylesheets/pages/main.scss
@@ -233,7 +233,7 @@ h3.container {
   display: inline-flex;
 
   .img-border {
-    display: inline-block;
+    flex-shrink: 0;
     height: 70px;
     width: 70px;
     border: 2px solid #f5f5f5;


### PR DESCRIPTION
dev
## ZeroWaste project

Ticket #453

## Code reviewers

- [x] @DmytroStoliaruk
- [ ] @loqimean

## Summary of issue

On the calculator page in 2nd section, images have different sizes.

## Summary of change

Changed image style.
##

<img width="1192" alt="image" src="https://github.com/ita-social-projects/ZeroWaste/assets/64698588/d6033e48-0d21-4d9e-8b2d-c8570399f456">

This PR closes https://github.com/ita-social-projects/ZeroWaste/issues/453 issue.