### PR TITLE
feature/change Search button style

### DIFF
--- a/app/views/account/calculators/index.html.slim
+++ b/app/views/account/calculators/index.html.slim
@@ -2,7 +2,7 @@
   = form_tag account_calculators_path, method: :get, class: 'd-flex justify-content-end mb-5' do
     .d-flex
       = text_field_tag :search, params[:search], class: 'form-control me-sm-2', placeholder: t('.search_placeholder')
-      = button_tag type: :submit, name: nil, class: 'btn btn-primary px-4 d-flex align-items-center' do
+      = button_tag type: :submit, name: nil, class: 'btn btn-outline-primary px-4 d-flex align-items-center' do
         i.fa.fa-search.me-2
         span =t('.search_button')
     = link_to new_account_calculator_path, class: 'btn btn-success px-4 ms-1' do


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #568 ](https://github.com/ita-social-projects/ZeroWaste/issues/568)

## Code reviewers

- [x] @Natali-Kotelnitska 
- [ ] @loqimean 

## Summary of issue

The text "Search" is white on the white Search button (Calculators page), and only visible on hover.

## Summary of change

Change style of the Search button.
![Button](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/a11ab5b3-7970-49bd-ad40-7ad4fa0181c0)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
