### PR TITLE
Site Settings rouring error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
       resources :messages, only: [:index, :show]
       resource :app_config, only: [:edit, :update]
       patch "/feature_flags", to: "feature_flags#update", as: "features_flags"
+      get "/site_setting", to: "site_settings#edit", as: "site_setting"
 
       resource :site_setting, only: [:edit, :update] do
         post :revert


### PR DESCRIPTION
dev
## Zerowaste

* [Project ticket #571](#571)


## Code reviewers

- [Ivan Marynych] @loqimean
- [ Oleksandr Lutsyuk] @fh0enix 

## Summary of issue

 Routing Error if you try to change application language after form validation error message. 
If you try to Apply invalid settings parameters (Title or Favicon) you will get a form validation error message (e.g. 'Title is too short (minimum is 3 characters)'). In this case, the view path will change from '/account/site_setting/edit' to '/account/site_setting'. The attempt to change locales generates a routing error. To solve this bug I add a new route '/account/site_setting'.

## Summary of change

Add new route to fix error

## CHECK LIST
- [x]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
