### PR TITLE
563 remove duplicate line in the config/initializers/simple_form_bootstrap.rb 

### DIFF
--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -4,7 +4,6 @@
 # https://github.com/heartcombo/simple_form-bootstrap
 # Please submit feedback, changes and tests only there.
 ALERT_DANGER           = "alert alert-danger"
-ALERT_DANGER           = "alert alert-danger"
 COL_FORM_LABEL         = "col-form-label pt-0"
 COL_FORM_LABEL_SM      = "col-sm-3 col-form-label"
 COL_FORM_LABEL_SM_PT   = "col-sm-3 col-form-label pt-0"


### PR DESCRIPTION
dev
## ZeroWaste Project

[Ticket #563 ](https://github.com/ita-social-projects/ZeroWaste/issues/563)

## Code reviewers

- [x] @fh0enix 
- [ ] @loqimean 

## Summary of issue
The config/initializers/simple_form_bootstrap.rb file contains the duplicate ALERT_DANGER on the line 6.

## Summary of change
Removed duplicate line.
<img width="590" alt="image" src="https://github.com/ita-social-projects/ZeroWaste/assets/64698588/e7e29954-a48d-4880-96d3-7114edf50a65">