### PR TITLE
#570--Products-page]-The-product-page-opens-after-clicking-on-the-"Delete"-button

### DIFF
--- a/app/views/account/products/index.html.slim
+++ b/app/views/account/products/index.html.slim
@@ -24,5 +24,5 @@
           td.actions
             = link_to edit_account_product_path(id: product) do
               i.fa.fa-pen.mx-2
-            = link_to account_product_path(id: product), method: :delete, data: { confirm: t('.confirm_delete') } do
+            = button_to account_product_path(id: product), method: :delete, data: { confirm: t('.confirm_delete') } do
               i.fa.fa-trash.mx-2

--- a/app/views/account/products/show.html.slim
+++ b/app/views/account/products/show.html.slim
@@ -18,6 +18,6 @@
         td.actions
           = link_to edit_account_product_path(id: @product) do
             i.fa.fa-pen.mx-2
-          = link_to account_product_path(id: @product), method: :delete,
+          = button_to account_product_path(id: @product), method: :delete,
                   data: { confirm: t('.confirm_delete') } do
             i.fa.fa-trash.mx-2


### PR DESCRIPTION
dev ticket
https://github.com/ita-social-projects/ZeroWaste/issues/570


## Code reviewers

- [x] @loqimean

### Second Level Review

- [x] @obniavko

## Summary of issue

fix bug => standard link_to to a button_to.

ToDo

## Summary of change

changes the link_to for deleting a product from a standard link_to to a button_to.

ToDo

## Testing approach

no needed

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
