### PR TITLE
fix Delete button on Calculators page

### DIFF
--- a/app/assets/stylesheets/pages/main.scss
+++ b/app/assets/stylesheets/pages/main.scss
@@ -308,12 +308,17 @@ body:where(.admin)::before {
   }
 
   .admin-table-links {
-    a {
+    a, form {
       color: $success;
 
       &:hover {
         color: #3d5217;
       }
+    }
+    
+    form {
+      display: inline-block;
+      transition: all 0.5s ease-in-out;
     }
 
     .admin-table-body {

--- a/app/controllers/account/calculators_controller.rb
+++ b/app/controllers/account/calculators_controller.rb
@@ -38,9 +38,9 @@ class Account::CalculatorsController < Account::BaseController
   end
 
   def destroy
-    @calculator.destroy!
+    @calculator.destroy
 
-    redirect_to account_calculators_path, notice: t("notifications.calculator_deleted")
+    redirect_to account_calculators_path, notice: t("notifications.calculator_deleted"), status: :see_other
   end
 
   private

--- a/app/views/account/calculators/index.html.slim
+++ b/app/views/account/calculators/index.html.slim
@@ -28,6 +28,6 @@
               i.fa.fa-eye.mx-2
             = link_to edit_account_calculator_path(slug: calculator) do
               i.fa.fa-pen.mx-2
-            = link_to account_calculator_path(slug: calculator), method: :delete,
-                    data: { confirm: t('.confirm_delete') } do
+            = button_to account_calculator_path(slug: calculator), method: :delete,
+                    data: { turbo_confirm: t('.confirm_delete') } do
               i.fa.fa-trash.mx-2

--- a/spec/requests/account/calculators_spec.rb
+++ b/spec/requests/account/calculators_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Account::CalculatorsController", type: :request do
+  include_context :authorize_admin
+  
+  let!(:calculator) { create(:calculator) }
+
+  describe "DELETE #destroy" do
+    it "destroys the calculator and redirects" do
+      expect do
+        delete account_calculator_path(calculator)        
+      end.to change(Calculator, :count).by(-1)      
+
+      expect(response).to redirect_to(account_calculators_path)
+      expect(flash[:notice]).to eq(I18n.t("notifications.calculator_deleted"))
+    end
+  end
+end

--- a/spec/requests/account/calculators_spec.rb
+++ b/spec/requests/account/calculators_spec.rb
@@ -4,14 +4,14 @@ require "rails_helper"
 
 RSpec.describe "Account::CalculatorsController", type: :request do
   include_context :authorize_admin
-  
+
   let!(:calculator) { create(:calculator) }
 
   describe "DELETE #destroy" do
     it "destroys the calculator and redirects" do
       expect do
-        delete account_calculator_path(calculator)        
-      end.to change(Calculator, :count).by(-1)      
+        delete account_calculator_path(calculator)
+      end.to change(Calculator, :count).by(-1)
 
       expect(response).to redirect_to(account_calculators_path)
       expect(flash[:notice]).to eq(I18n.t("notifications.calculator_deleted"))


### PR DESCRIPTION
dev
## ZeroWaste project

* [project ticket #564](https://github.com/orgs/ita-social-projects/projects/25/views/7?pane=issue&itemId=44965204)


## Code reviewers

- [ ] @loqimean

### Second Level Review

- [ ] @dafeys

## Summary of issue
The delete calculator button did not work on the Calculators page in the site admin panel. 
Actual result: HTTP ERROR 406 after click on Delete icon.
Expected result: the corresponding calculator must be removed

View on click:
![Screenshot 2023-11-24 040013](https://github.com/ita-social-projects/ZeroWaste/assets/25872733/56ae9384-7dfc-49e4-949e-7506e5189088)

## Summary of change
1. Fixed Delete button and Confirm message.
2. Added appropriate styles for the icon.

View on click:
![Screenshot 2023-11-24 072906](https://github.com/ita-social-projects/ZeroWaste/assets/25872733/c0f1acb6-7397-47f9-87b2-50238ec80682)


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
