### PR TITLE
Remove irrelevant parameters in the URI address

### DIFF
--- a/app/views/account/categories/index.html.slim
+++ b/app/views/account/categories/index.html.slim
@@ -1,7 +1,7 @@
 .container
   = form_tag account_category_path(id: @categories), method: :get, class: 'd-flex justify-content-end mb-5' do
     .d-flex
-    = link_to new_account_category_path(id: @categories), class: 'btn btn-success px-4 ms-1' do
+    = link_to new_account_category_path, class: 'btn btn-success px-4 ms-1' do
       i.fa.fa-plus.me-2
       span =t('.add_category_button')
 


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #578](https://github.com/ita-social-projects/ZeroWaste/issues/578)

## Code reviewers

- [x]  @obniavko
- [ ] @loqimean 

## Summary of issue

The address bar contains: https://zero-waste-staging.onrender.com/en/account/categories/new?id=%23%3CCategory%3A%3AActiveRecord_Relation%3A0x00007f08dab32c68%3E), but should contain:
[https://zero-waste-staging.onrender.com/en/account/categories/new](https://zero-waste-staging.onrender.com/en/account/categories/new?id=%23%3CCategory%3A%3AActiveRecord_Relation%3A0x00007f08dab32c68%3E)

## Summary of change
removed irrelevant parameters in the URI address

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions