### PR TITLE
Add hover effect for "How to use less" button

### DIFF
--- a/app/assets/stylesheets/pages/calculator.scss
+++ b/app/assets/stylesheets/pages/calculator.scss
@@ -171,6 +171,9 @@
     background-color: transparent;
     text-decoration: none;
   }
+  &:hover {
+    background-color: $dark_green;
+  }
 }
 
 .col-xl-8.result-card {


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #579](https://github.com/ita-social-projects/ZeroWaste/issues/579)

## Code reviewers

- [ ] @dafeys 
- [ ] @loqimean 

## Summary of issue

The color of "_How to use less_" button does not change on hover.

## Summary of change

Added hover effect for "_How to use less_" button.
![Button2](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/4082d92c-caf9-45dc-97a7-c34929e657f9)

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions