### PR TITLE
feature/add menu items to the navbar

### DIFF
--- a/app/assets/stylesheets/pages/main.scss
+++ b/app/assets/stylesheets/pages/main.scss
@@ -126,7 +126,7 @@ a {
 .tab {
   text-transform: uppercase;
   font-size: 14px;
-  padding: 33px 25px;
+  padding: 33px 15px;
   color: $color;
   border-bottom: 3px solid transparent;
   @include transition(all 0.5s ease-in-out);
@@ -315,7 +315,7 @@ body:where(.admin)::before {
         color: #3d5217;
       }
     }
-    
+
     form {
       display: inline-block;
       transition: all 0.5s ease-in-out;

--- a/app/views/account/shared/_navigation.html.slim
+++ b/app/views/account/shared/_navigation.html.slim
@@ -2,6 +2,12 @@ body
   header.page-header
     = link_to image_tag('logo_zerowaste.png'), root_path, class: 'logo-zerowaste'
     .tabs
+      - if Flipper[:show_calculators_list].enabled?
+        = link_to t('.calculators'), calculators_path, class: 'tab'
+      - else
+        = link_to t('layouts.navigation.calculate'), calculator_path, class: 'tab'
+      = link_to t('layouts.navigation.about_us'), about_us_path, class: 'tab'
+      = link_to t('layouts.navigation.contact_us'), new_message_path, class: 'tab'
       - if user_signed_in?
         - if current_user.admin?
           = link_to t('layouts.navigation.admin'), account_calculators_path, class: 'tab'
@@ -9,9 +15,6 @@ body
       - else
         = link_to t('layouts.navigation.sign_up'), new_user_registration_path, class: 'tab'
         = link_to t('layouts.navigation.log_in'), new_user_session_path, class: 'tab', id: 'log_in'
-      = link_to t('layouts.navigation.contact_us'), new_message_path, class: 'tab'
-      - if Flipper[:show_calculators_list].enabled?
-        = link_to t('.calculators'), calculators_path, class: 'tab'
     .func-btns.d-inline
       = link_to t('.donate'), "https://zerowastelviv.org.ua/pidtrymaty/", target: '_blank', class: "d-inline main-btn btn-green me-2"
       = link_to t("#{switch_locale_to}"), url_for(locale: switch_locale_to), class: 'd-inline main-btn btn-gray'

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -84,7 +84,9 @@ en:
         other: "%{count} years"
   layouts:
     navigation:
+      about_us: "About us"
       admin: "Admin"
+      calculate: "Diaper calculator"
       log_out: "Log Out"
       sign_up: "Sign Up"
       log_in: "Log In"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -63,7 +63,9 @@ uk:
         other: "%{count} років"
   layouts:
     navigation:
+      about_us: "Про нас"
       admin: "Адміністратор"
+      calculate: "Калькулятор підгузків"
       log_out: "Вийти"
       sign_up: "Зареєструватися"
       log_in: "Увійти"


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #585 ](https://github.com/ita-social-projects/ZeroWaste/issues/585)

## Code reviewers
- [x] @iryna-borniak
- [ ] @loqimean 

## Summary of issue

The site menu should contain additional menu items such as "About us", and "Diaper calculator"/"Calculators" (if the feature flag is enabled) which lead to the corresponding pages.

## Summary of change

Added additional menu items such as "About us", and "Diaper calculator"/"Calculators".
Changed the order of menu items for the user convenience.
![Navbar](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/2c9c9c0f-3b35-461d-84f7-79a5d161734e)


## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions