### PR TITLE
Fix "To main" button

### DIFF
--- a/app/assets/stylesheets/pages/calculator.scss
+++ b/app/assets/stylesheets/pages/calculator.scss
@@ -42,6 +42,9 @@
 
 .back-text {
   color: black;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
 }
 
 .calulator-arrow {

--- a/app/assets/stylesheets/pages/calculator.scss
+++ b/app/assets/stylesheets/pages/calculator.scss
@@ -45,6 +45,7 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  gap: 0.5rem;
 }
 
 .calulator-arrow {

--- a/app/views/calculators/new_calculator.html.slim
+++ b/app/views/calculators/new_calculator.html.slim
@@ -1,8 +1,8 @@
 .jumbotron.jumbotron-fluid.position-relative.rounded
   a.rounded.back-link.mt-3.px-2 href=root_path
     .p.back-text
+      = image_tag "icons/arrow-left.svg", class: "z-1"
       = t 'calculators.buttons.to_main'
-    = image_tag "icons/arrow-left.svg", class: "z-1"
   .d-flex.justify-content-around.flex-wrap.calculator_wrap.ms-5
     = simple_form_for(:child, url: "#", html: { class: "simple_form_calculator",
                                             data: { controller: "input-child-info",


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #588] 

## Code reviewers

- [x] @obniavko 
- [ ] @loqimean 

## Summary of issue
When we click the "Let's go" button, You will see that the arrow and the text "To main" are placed on different lines and should be on the same line.
## Summary of change
Fixed  button "To main", such as arrow and text are on the same line.
<img width="535" alt="Fixed button1" src="https://github.com/ita-social-projects/ZeroWaste/assets/129009813/3336537b-4a34-4dee-aab6-242b83332e31">




## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
