### PR TITLE
610 fix buttons size on categories/new

### DIFF
--- a/app/assets/stylesheets/pages/account.scss
+++ b/app/assets/stylesheets/pages/account.scss
@@ -76,3 +76,18 @@ $burger-size: 20px;
   transform: rotate(0deg);
   transition: .25s;
 }
+
+.button-group {
+  .btn {
+    min-width: 120px;
+  }
+
+  .btn-danger {
+    border: none;
+    padding: 10px;
+
+    &:hover {
+      color: black;
+    }
+  }
+}

--- a/app/views/account/categories/new.html.slim
+++ b/app/views/account/categories/new.html.slim
@@ -13,8 +13,7 @@ few
       .col-12.has-float-label.my-auto
         = f.input :name, class: 'form-control col-sm-11', required: true
         = f.input :priority, class: 'form-control col-sm-11', input_html: { min: 0 }
-    .div.d-flex
-        = f.submit t('buttons.create'), class: 'btn btn-success me-2 height-auto w-auto'
-        = link_to account_categories_path, class: 'btn btn-danger d-flex align-items-center justify-content-center height-auto w-auto' do
-          span.me-1 =t('buttons.cancel')
-          i.fa.fa-times-circle
+    .div.button-group.d-flex
+        = f.submit t('buttons.create'), class: 'btn btn-success me-2'
+        = link_to account_categories_path, class: 'btn btn-danger d-flex align-items-center justify-content-center' do
+          span = t('buttons.cancel')          


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #610](https://github.com/ita-social-projects/ZeroWaste/issues/610)


## Code reviewers

- [ ] @loqimean

### Second Level Review

- [x] @DmytroStoliaruk

## Summary of issue

The sizes of the "Create" and "Cancel" buttons are different

## Summary of change

1. The size of the "Create" and "Cancel" buttons has been made equal
2. The icon on the "Cancel" button has been removed
3. Added hover for text on the "Cancel" button the same as on the "Create" one

![Screenshot 2023-12-05 220601](https://github.com/ita-social-projects/ZeroWaste/assets/25872733/b487b9d4-07e7-4955-a381-2e5877a771f1)

![Screenshot 2023-12-05 220536](https://github.com/ita-social-projects/ZeroWaste/assets/25872733/0c219e23-a69f-4d21-a72c-83433dba21e1)

Look on hover:

![Screenshot 2023-12-05 220645](https://github.com/ita-social-projects/ZeroWaste/assets/25872733/aef3392e-abd6-4ecc-85e2-f616eb1f2203)

![Screenshot 2023-12-05 220620](https://github.com/ita-social-projects/ZeroWaste/assets/25872733/bf08d5ff-6206-42ce-b889-a31577d70c4c)

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
