### PR TITLE
616 tooltip text

### DIFF
--- a/config/locales/en/simple_form.en.yml
+++ b/config/locales/en/simple_form.en.yml
@@ -1,0 +1,8 @@
+en:
+  simple_form:
+    labels:
+      defaults:
+        required: "%{text} %{mark}"
+    required:
+      text: "Required"
+      mark: "*"

--- a/config/locales/uk/simple_form.uk.yml
+++ b/config/locales/uk/simple_form.uk.yml
@@ -1,0 +1,8 @@
+uk:
+  simple_form:
+    labels:
+      defaults:
+        required: "%{text} %{mark}"
+    required:
+      text: "Обовʼязкове поле"
+      mark: "*"


### PR DESCRIPTION
dev
## ZeroWaste project

https://github.com/ita-social-projects/ZeroWaste/issues/616


## Code reviewers

- [ ] @loqimean 

### Second Level Review

- [x] @dafeys 

## Summary of issue

On required form field tooltip spelled in lowercase while should be capitalised.

## Summary of change

Changed tooltip text for both English and Ukrainian locales.
<img width="144" alt="image" src="https://github.com/ita-social-projects/ZeroWaste/assets/64698588/0c8c09f8-18e5-4a1d-be5f-c8774dfbf517">
<img width="220" alt="image" src="https://github.com/ita-social-projects/ZeroWaste/assets/64698588/28e19e97-77fc-40e6-b02a-2207c688b416">
