### PR TITLE
Fix favicon dissapears

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,10 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+render:
+  service: Disk
+  root: "/opt/activestorage-data"
+
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
dev ticket
https://github.com/ita-social-projects/ZeroWaste/issues/532


## Code reviewers

- [x] @loqimean

### Second Level Review

- [x] @iryna-borniak

## Summary of issue

So, the reason why the favicon is not being saved is that there is no specified path for storage on external services in the config file storage.yml. If this concerns rendering, there should be a separate line:

render:
  service: Disk
  root: '/opt/activestorage-data'

This is to allow Active Storage to save it remotely on that service rather than locally. This situation applies to other hostings where the application is deployed. So, on a remote hosting, Redis fetches the favicon, stores it in the cache, and then the cache hangs for some time and crashes. This happens because Active Storage is not activated and not configured in this file.

ToDo

## Summary of change

Added render service to storage.yml

ToDo

## Testing approach

no needed

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
