### PR TITLE
Fix/Add max length validations for the 'First Name' and 'Last Name' fields

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,7 +74,7 @@ class User < ApplicationRecord
             unless: :skip_password_validation
   validates :first_name, :last_name,
             presence: true,
-            length: { minimum: 2 },
+            length: { in: 2..50 },
             on: [:create, :update],
             format: { with: /[a-zA-Zа-їА-ЯЄІЇ]+-?'?`?/ }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -56,13 +56,13 @@ RSpec.describe User, type: :model do
 
     it { is_expected.to validate_presence_of(:first_name).on(:create) }
     it { is_expected.to validate_presence_of(:first_name).on(:update) }
-    it { is_expected.to validate_length_of(:first_name).is_at_least(2).on(:create) }
-    it { is_expected.to validate_length_of(:first_name).is_at_least(2).on(:update) }
+    it { is_expected.to validate_length_of(:first_name).is_at_least(2).is_at_most(50).on(:create) }
+    it { is_expected.to validate_length_of(:first_name).is_at_least(2).is_at_most(50).on(:update) }
 
     it { is_expected.to validate_presence_of(:last_name).on(:create) }
     it { is_expected.to validate_presence_of(:last_name).on(:update) }
-    it { is_expected.to validate_length_of(:last_name).is_at_least(2).on(:create) }
-    it { is_expected.to validate_length_of(:last_name).is_at_least(2).on(:update) }
+    it { is_expected.to validate_length_of(:last_name).is_at_least(2).is_at_most(50).on(:create) }
+    it { is_expected.to validate_length_of(:last_name).is_at_least(2).is_at_most(50).on(:update) }
 
     it { is_expected.to allow_value("email@gmail.com").for(:email) }
     it { is_expected.not_to allow_value("email.factory-com").for(:email) }


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #646 ](https://github.com/ita-social-projects/ZeroWaste/issues/646)

## Code reviewers

- [x] @DmytroStoliaruk 
- [ ] @loqimean 

## Summary of issue

There are no error messages in regards of 'First Name' and 'Last Name' fields on Sign up page. The system shows that entered data is correct and text fields are highlighted in green color. Developers Team and Tech Expert agreed the maximum for entering - 50 characters for First and Last Name fields.

## Summary of change

Added max length validations for the 'First Name' and 'Last Name' fields (50 characters) and updated corresponding tests.

![50](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/ee65c07f-7a7f-44d7-8b30-2bbce7a38b83)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions