### PR TITLE
fix/ Routing error when changing the language version on a Sign up page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,12 @@ Rails.application.routes.draw do
   get "/", to: "application#redirection", as: :root_redirection
 
   scope "/(:locale)", locale: /uk|en/ do
-    devise_for :users, controllers: { registrations: "users/registrations" },
-                       skip: :omniauth_callbacks
+    devise_for :users, skip: [:omniauth_callbacks, :registration]
+
+    as :user do
+      get :sign_up, to: "users/registrations#new", as: :new_user_registration
+      post :sign_up, to: "users/registrations#create", as: :user_registration
+    end
 
     root "home#index"
     get "/sitemap", to: "sitemap#index"


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #618 ](https://github.com/ita-social-projects/ZeroWaste/issues/618)

## Code reviewers

- [ ] @DmytroStoliaruk 
- [ ] @loqimean 

## Summary of issue

The button link leads to the non-existent [/users page](https://zero-waste-staging.onrender.com/uk/users) when changing the language version after a failed registration attempt on a Sign up page.

## Summary of change

Updated routes for a Sign up.

![SignUp](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/594a88bf-907f-4f72-9048-6418ebf6bcc8)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions