### PR TITLE
Fix incorrect label on button, incorrect label in Ukrainian localization

### DIFF
--- a/app/views/account/calculators/new.html.slim
+++ b/app/views/account/calculators/new.html.slim
@@ -14,5 +14,4 @@
     .div.d-flex
       = f.button :submit, t('.create_calculator_button'), class: 'btn btn-success me-2 height-auto w-auto'
       = link_to account_calculators_path, class: 'btn btn-danger d-flex align-items-center justify-content-center height-auto w-auto' do
-        span.me-1 = t('.cancel_button')
-        i.fa.fa-times-circle
+        span = t('.cancel_button')

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -258,6 +258,7 @@ uk:
           update_calculator_button: "Оновити калькулятор"
       new:
         create_calculator_button: "Створити калькулятор"
+        cancel_button: "Скасувати"
         prohibited_to_update: " перешкоджають оновленню калькулятора"
         prohibited_to_save: " перешкоджають збереженню калькулятора"
         error: "помилки"


### PR DESCRIPTION
[Calculator -> 'Add calculator' button] Incorrect label on button, button label is not switched to black after hovering it, incorrect label in Ukrainian localization#624](https://github.com/ita-social-projects/ZeroWaste/issues/624)

Code reviewers
@obniavko
@loqimean

Summary of issue
Incorrect label on button, incorrect label in Ukrainian localization
<img width="446" alt="Cancel1" src="https://github.com/ita-social-projects/ZeroWaste/assets/129009813/bdc3c4f7-21c6-4abf-9aba-71c1b82ed5c0">



Summary of change
Removed the closing icon from "Cancel button".'Cкасувати' button label is in Ukrainian


