### PR TITLE
Fix "Update product" button text

### DIFF
--- a/app/views/account/categories/edit.html.erb
+++ b/app/views/account/categories/edit.html.erb
@@ -7,7 +7,7 @@
       </div>
     </div>
     <div class="button-group d-flex">
-      <%= f.submit t('buttons.update'), class: 'btn btn-green me-2 height w-auto' %>
+      <%= f.submit t('.form.update_category_button'), class: 'btn btn-green me-2 height w-auto' %>
       <%= link_to account_categories_path, class: 'btn btn-danger d-flex align-items-center justify-content-center' do %>
         <span class="me-1"><%= t('buttons.cancel') %></span>
       <% end %>

--- a/app/views/account/categories/new.html.erb
+++ b/app/views/account/categories/new.html.erb
@@ -6,7 +6,7 @@
     </div>
   </div>
   <div class="button-group d-flex">
-    <%= f.submit t('buttons.create'), class: 'btn btn-green me-2' %>
+    <%= f.submit t('.form.create_category_button'), class: 'btn btn-green me-2' %>
     <%= link_to account_categories_path, class: 'btn btn-danger d-flex align-items-center justify-content-center' do %>
       <span><%= t('buttons.cancel') %></span>
     <% end %>

--- a/app/views/account/products/edit.html.erb
+++ b/app/views/account/products/edit.html.erb
@@ -19,7 +19,7 @@
       </div>
     </div>
     <div class="mt-2 button-group d-flex">
-      <%= f.submit t('buttons.create'), class: 'btn btn-green me-2' %>
+      <%= f.submit t('.form.update_product_button'), class: 'btn btn-green me-2' %>
       <%= link_to account_products_path, class: 'btn btn-danger d-flex align-items-center justify-content-center' do %>
         <span class="me-1"><%= t('buttons.cancel') %></span>
       <% end %>

--- a/app/views/account/products/new.html.erb
+++ b/app/views/account/products/new.html.erb
@@ -18,7 +18,7 @@
       </div>
     </div>
     <div class="mt-2 button-group d-flex">
-      <%= f.submit t('buttons.create'), class: 'btn btn-green me-2 w-auto' %>
+      <%= f.submit t('.form.create_product_button'), class: 'btn btn-green me-2 w-auto' %>
       <%= link_to account_products_path, class: 'btn btn-danger d-flex align-items-center justify-content-center' do %>
         <span class="me-1"><%= t('buttons.cancel') %></span>
       <% end %>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -186,6 +186,12 @@ en:
       index:
         add_category_button: 'Add category'
         confirm_delete: 'Delete category?'
+      edit:
+        form:
+          update_category_button: "Update category"
+      new:
+        form:
+          create_category_button: "Create category"
     products:
       table:
         title: 'Title'
@@ -200,10 +206,12 @@ en:
         title: 'Title'
         form:
           sum: "Sum"
+          update_product_button: "Update product"
       new:
         title: 'Title'
         form:
           sum: "Sum"
+          create_product_button: "Create product"
       created: "A product was successfully created."
       updated: "A product was successfully updated."
       deleted: "A product was successfully destroyed."
@@ -290,7 +298,7 @@ en:
       show_calculators_list:
         name: "Show calculators on the public side"
       sandbox_mode:
-        name: "Enable sandbox mode"  
+        name: "Enable sandbox mode"
     sessions:
       new:
         log_in_header: "Log in"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -169,6 +169,12 @@ uk:
           priority: "Пріоритет"
         add_category_button: "Додати категорію"
         confirm_delete: "Видалити категорію?"
+      edit:
+        form:
+          update_category_button: "Оновити категорію"
+      new:
+        form:
+          create_category_button: "Створити категорію"
     products:
       index:
         table:
@@ -187,10 +193,12 @@ uk:
         title: "Назва"
         form:
           sum: "Сума"
+          update_product_button: "Оновити продукт"
       new:
         title: "Назва"
         form:
           sum: "Сума"
+          create_product_button: "Створити продукт"
       created: "Продукт був успішно створений."
       updated: "Продукт був успішно оновлений."
       deleted: "Продукт був успішно видалений."


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #727](https://github.com/ita-social-projects/ZeroWaste/issues/727)

## Code reviewers

- [x] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

The button on "Edit product" page has text "Create".

## Summary of change

Fixed button text.

![button-text](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/8c08d96e-3c35-4a04-ac59-69a88e38f09d)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions