### PR TITLE
Fix/ 'Password' label is not required

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="position-block">
   <div class="card">
-    <div class="card-block p-4">
-      <h2 class="text-center p-2"><%= t('.log_in') %></h2>
+    <div class="p-4 card-block">
+      <h2 class="p-2 text-center"><%= t('.log_in') %></h2>
 
       <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <% flash.each do |type, msg| %>
@@ -12,7 +12,7 @@
 
         <%= f.input :email, class: 'form-control', autofocus: true, autocomplete: "email" %>
         <div class="password-wrapper-login" data-controller="password-visibility">
-          <%= f.input :password, input_html: { class: 'form-control password-field', autocomplete: "current-password", data: { password_visibility_target: 'password' }, spellcheck: false } %>
+          <%= f.input :password, input_html: { class: 'form-control password-field', autocomplete: "current-password", data: { password_visibility_target: 'password' }, spellcheck: false }, required: true %>
           <%= render 'shared/password_icon' %>
         </div>
 
@@ -20,7 +20,7 @@
           <%= f.input :remember_me, as: :boolean, inline_label: true %>
         <% end %>
 
-        <div class="d-flex justify-content-between flex-wrap flex-row-reverse align-content-center">
+        <div class="flex-row-reverse flex-wrap d-flex justify-content-between align-content-center">
           <%= f.submit t('.log_in'), class: "btn btn-primary" %>
           <div class="d-block">
             <%= render "devise/shared/links" %>


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #734](https://github.com/ita-social-projects/ZeroWaste/issues/734)

## Code reviewers

- [ ] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

'Password' label is not described as required field and it is not marked with an asterisk.

## Summary of change

Made 'Password' field required.

![Password](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/08ebce5f-b7f3-4e0d-b024-3fe6621d9f1a)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions