### PR TITLE
Fix/ Negative value of Sum

### DIFF
--- a/app/models/price.rb
+++ b/app/models/price.rb
@@ -23,5 +23,6 @@ class Price < ApplicationRecord
   belongs_to :category, optional: true
 
   validates :sum, presence: true
+  validates :sum, numericality: { greater_than_or_equal_to: 0 }
   validates :category_id, uniqueness: { scope: [:priceable_id, :priceable_type] }
 end

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -446,6 +446,8 @@ uk:
       category:
         name: "Назва"
         priority: "Пріоритет"
+      price:
+        sum: "Сума"
       product:
         title: "Назва"
     errors:

--- a/spec/models/price_spec.rb
+++ b/spec/models/price_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe Price, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:sum) }
 
+    it { is_expected.to validate_numericality_of(:sum).is_greater_than_or_equal_to(0) }
+
     it { is_expected.to validate_uniqueness_of(:category_id).scoped_to(:priceable_id, :priceable_type) }
   end
 end


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #733](https://github.com/ita-social-projects/ZeroWaste/issues/733)

## Code reviewers

- [x] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

The product can be created with negative value of Sum.

## Summary of change

1. Limited Sum input to numbers greater than or equal to zero.

![Sum](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/fa312d95-204f-4e2a-b6cc-b3bf3f5f3e4b)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions