### PR TITLE
Fix/ Entered data and error messages are duplicated after an attempt to create the product with invalid data

### DIFF
--- a/app/controllers/account/products_controller.rb
+++ b/app/controllers/account/products_controller.rb
@@ -10,8 +10,6 @@ class Account::ProductsController < Account::BaseController
 
   def new
     @product = Product.new
-
-    @product.prices.build
   end
 
   def edit
@@ -26,8 +24,6 @@ class Account::ProductsController < Account::BaseController
     if @product.save
       redirect_to account_products_path, notice: t(".created")
     else
-      @product.prices.build
-
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -41,6 +41,10 @@ class Product < ApplicationRecord
     prices.where(category: category).first
   end
 
+  def find_or_build_price_for_category(category)
+    prices.find_by(category: category) || prices.build(category: category)
+  end
+
   def build_unsigned_categories
     unsigned_categories = Category.unsigned_categories(self)
 

--- a/app/views/account/products/new.html.erb
+++ b/app/views/account/products/new.html.erb
@@ -2,14 +2,14 @@
   <%= simple_form_for @product, url: account_products_path, data: { controller: "price-form" } do |f| %>
     <div class="form-group row">
       <div class="my-auto col-12 has-float-label">
-        <%= f.input :title, label: t('.title'), class: 'form-control col-sm-11' %>
+        <%= f.input :title, label: t(".title"), class: "form-control col-sm-11" %>
         <% Category.ordered_by_name.each do |category| %>
           <div class="checkbox-blocks">
-            <%= check_box_tag category.name, 1, false, data: { action: "click->price-form#togglePrice", price_form_target: 'checkbox' }, class: 'me-1' %>
+            <%= check_box_tag category.name, 1, false, data: { action: "click->price-form#togglePrice", price_form_target: "checkbox" }, class: "me-1" %>
             <%= label_tag category.name %>
             <div class="hidden-sum" data-price-form-target="price" name="<%= category.name %>">
-              <%= f.simple_fields_for :prices, f.object.prices.find { |price| price.category == category } || f.object.prices.build(category: category) do |prices_form| %>
-                <%= prices_form.input :sum, label: false, input_html: { placeholder: t('.form.sum'), data: { price_form_target: 'priceInput' } } %>
+              <%= f.simple_fields_for :prices, f.object.find_or_build_price_for_category(category) do |prices_form| %>
+                <%= prices_form.input :sum, label: false, input_html: { placeholder: t(".form.sum"), data: { price_form_target: "priceInput" } } %>
                 <%= prices_form.hidden_field :category_id, value: category.id %>
               <% end %>
             </div>
@@ -18,9 +18,9 @@
       </div>
     </div>
     <div class="mt-2 button-group d-flex">
-      <%= f.submit t('.form.create_product_button'), class: 'btn btn-green me-2 w-auto' %>
-      <%= link_to account_products_path, class: 'btn btn-danger d-flex align-items-center justify-content-center' do %>
-        <span class="me-1"><%= t('buttons.cancel') %></span>
+      <%= f.submit t(".form.create_product_button"), class: "btn btn-green me-2 w-auto" %>
+      <%= link_to account_products_path, class: "btn btn-danger d-flex align-items-center justify-content-center" do %>
+        <span class="me-1"><%= t("buttons.cancel") %></span>
       <% end %>
     </div>
   <% end %>

--- a/app/views/account/products/new.html.erb
+++ b/app/views/account/products/new.html.erb
@@ -8,7 +8,7 @@
             <%= check_box_tag category.name, 1, false, data: { action: "click->price-form#togglePrice", price_form_target: 'checkbox' }, class: 'me-1' %>
             <%= label_tag category.name %>
             <div class="hidden-sum" data-price-form-target="price" name="<%= category.name %>">
-              <%= f.simple_fields_for :prices do |prices_form| %>
+              <%= f.simple_fields_for :prices, f.object.prices.find { |price| price.category == category } || f.object.prices.build(category: category) do |prices_form| %>
                 <%= prices_form.input :sum, label: false, input_html: { placeholder: t('.form.sum'), data: { price_form_target: 'priceInput' } } %>
                 <%= prices_form.hidden_field :category_id, value: category.id %>
               <% end %>


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #741](https://github.com/ita-social-projects/ZeroWaste/issues/741)
* [Project ticket #743](https://github.com/ita-social-projects/ZeroWaste/issues/743)
* [Project ticket #744](https://github.com/ita-social-projects/ZeroWaste/issues/744)
* [Project ticket #745](https://github.com/ita-social-projects/ZeroWaste/issues/745)

## Code reviewers

- [x] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

1. The chosen category checkbox is unchecked
2. 'Сума' fields are displayed near the categories with the unchecked checkbox
3. 'Сума' field with the entered data is duplicated near the categories with the unchecked checkbox
4. The "Сума мусить бути більше ніж або дорівнювати 0" error message is duplicated near the categories with the unchecked checkbox

## Summary of change

1. Fixed duplication error.

![Validation-errors](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/fa7c332e-e747-4d25-a4d4-f982be3f212c)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions