### PR TITLE
Fix/ Remove duplicate error notification

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,15 +1,9 @@
 <div class="position-block">
   <div class="card">
-    <div class="card-block p-4">
-      <h2 class="text-center p-2"><%= t(".log_in") %></h2>
+    <div class="p-4 card-block">
+      <h2 class="p-2 text-center"><%= t(".log_in") %></h2>
 
       <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-        <% flash.each do |type, msg| %>
-          <div class="alert alert-danger">
-            <%= msg %>
-          </div>
-        <% end %>
-
         <%= f.input :email, class: "form-control", autofocus: true, autocomplete: "email" %>
         <div class="password-wrapper-login" data-controller="password-visibility">
           <%= f.input :password, input_html: { class: 'form-control password-field', autocomplete: "current-password", data: { password_visibility_target: 'password' }, spellcheck: false }, required: true %>
@@ -20,7 +14,7 @@
           <%= f.input :remember_me, as: :boolean, inline_label: true %>
         <% end %>
 
-        <div class="flex flex-wrap flex-row-reverse content-center gap-3">
+        <div class="flex flex-row-reverse flex-wrap content-center gap-3">
           <%= f.submit t(".log_in"), class: "btn btn-primary" %>
 
           <%= render "devise/shared/links" %>


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #735](https://github.com/ita-social-projects/ZeroWaste/issues/735)

## Code reviewers

- [x] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

Two 'Invalid Email or password.' error messages appear.

## Summary of change

Removed duplicate error notification.
**Note:** It is common on login forms to see "Email or password is incorrect" when the user types in their account details incorrectly instead of just "password is incorrect". This is, for among other reasons, because it is a security vulnerability to inform users that the Email is indeed registered to that site.

![Sign_in](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/e49c204c-f2ff-46cd-85be-97658e93dbd6)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions