### PR TITLE
720 fix revert btn

### DIFF
--- a/app/assets/stylesheets/pages/feature_flags.scss
+++ b/app/assets/stylesheets/pages/feature_flags.scss
@@ -49,13 +49,14 @@ input[type="submit"] {
   font-size: 16px;
   padding: 10px;
   min-width: 110px;
+  @include transition(all 0.5s ease-in-out);
 
   &:hover {
     background-color: $matte_lime_green;
   }
 }
 
-button.btn-grey, a.btn-grey {
+.btn-grey {
   background-color: $grey;
   border: none;
   border-radius: 4px;
@@ -65,14 +66,11 @@ button.btn-grey, a.btn-grey {
   padding: 10px;
   min-width: 110px;
   text-align: center;
+  @include transition(all 0.5s ease-in-out);
 
   &:hover {
     background-color: $dark_gray;
   }
-}
-
-button.btn-grey {
-  margin-left: 20px;
 }
 
 .right-bottom {

--- a/app/controllers/account/site_settings_controller.rb
+++ b/app/controllers/account/site_settings_controller.rb
@@ -18,6 +18,8 @@ class Account::SiteSettingsController < Account::BaseController
   end
 
   def revert
+    @site_setting = resource
+
     if SiteSetting.restore_defaults!
       redirect_to edit_account_site_setting_path, notice: t("notifications.site_setting_reverted")
     else

--- a/app/controllers/account/site_settings_controller.rb
+++ b/app/controllers/account/site_settings_controller.rb
@@ -20,13 +20,16 @@ class Account::SiteSettingsController < Account::BaseController
   def revert
     @site_setting = resource
 
-    @site_setting.update(title: "ZeroWaste", favicon: {
+    if @site_setting.update(title: "ZeroWaste", favicon: {
       io: File.open("app/assets/images/icons/favicon-48x48.png"),
       filename: "favicon-48x48.png",
       content_type: "image/png"
     })
 
-    redirect_to edit_account_site_setting_path, notice: t("notifications.site_setting_reverted")
+      redirect_to edit_account_site_setting_path, notice: t("notifications.site_setting_reverted")
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/controllers/account/site_settings_controller.rb
+++ b/app/controllers/account/site_settings_controller.rb
@@ -18,14 +18,7 @@ class Account::SiteSettingsController < Account::BaseController
   end
 
   def revert
-    @site_setting = resource
-
-    if @site_setting.update(title: "ZeroWaste", favicon: {
-      io: File.open("app/assets/images/icons/favicon-48x48.png"),
-      filename: "favicon-48x48.png",
-      content_type: "image/png"
-    })
-
+    if SiteSetting.restore_defaults!
       redirect_to edit_account_site_setting_path, notice: t("notifications.site_setting_reverted")
     else
       render :edit, status: :unprocessable_entity

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -25,6 +25,19 @@ class SiteSetting < ApplicationRecord
 
   singleton_class.alias_method :current, :instance
 
+  def self.restore_defaults!
+    default_attributes = {
+      title: "ZeroWaste",
+      favicon: {
+        io: File.open("app/assets/images/icons/favicon-48x48.png"),
+        filename: "favicon-48x48.png",
+        content_type: "image/png"
+      }
+    }
+
+    SiteSetting.current.update(default_attributes)
+  end
+
   private
 
   def set_default_favicon

--- a/app/views/account/site_settings/edit.html.erb
+++ b/app/views/account/site_settings/edit.html.erb
@@ -17,7 +17,7 @@
     <% end %>
 
     <%= button_to t("buttons.revert"), revert_account_site_setting_path,
-                  method: :patch,
+                  method: :put,
                   data: { turbo_confirm: t(".confirm_default") },
                   class: "btn-grey absolute bottom-0 left-0 ml-32" %>
   </div>

--- a/app/views/account/site_settings/edit.html.erb
+++ b/app/views/account/site_settings/edit.html.erb
@@ -8,14 +8,18 @@
         <div class="my-auto col-12 has-float-label">
           <%= f.input :title, class: "form-control", input_html: { data: { action: "input->handle-browser-tab#setTitle" } } %>
           <%= f.input :favicon, wrapper: :custom_vertical_file, input_html: { data: { action: "change->handle-browser-tab#setIcon" } } %>
-          <div class="mb-2">
+          <div class="mb-10">
             <%= render "browser_tab", site_setting: @site_setting %>
           </div>
         </div>
       </div>
-      <%= f.submit t("buttons.save") %>
-      <%= button_to t("buttons.revert"), revert_account_site_setting_path, onclick: "return confirm('#{j(t('.confirm_default'))}')", class: "px-4 py-2.5 my-4 btn-grey w-min" %>
+      <%= f.submit t("buttons.save") %>      
     <% end %>
+
+    <%= button_to t("buttons.revert"), revert_account_site_setting_path,
+                  method: :patch,
+                  data: { turbo_confirm: t(".confirm_default") },
+                  class: "btn-grey absolute bottom-0 left-0 ml-32" %>
   </div>
 </fieldset>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,6 @@ Rails.application.routes.draw do
       resources :messages, only: [:index, :show]
       resource :app_config, only: [:edit, :update]
       patch "/feature_flags", to: "feature_flags#update", as: "features_flags"
-      get "/site_setting", to: "site_settings#edit", as: "site_setting"
 
       resource :site_setting, only: [:edit, :update] do
         patch :revert

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
       get "/site_setting", to: "site_settings#edit", as: "site_setting"
 
       resource :site_setting, only: [:edit, :update] do
-        post :revert
+        patch :revert
       end
 
       scope module: :calculators do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
       patch "/feature_flags", to: "feature_flags#update", as: "features_flags"
 
       resource :site_setting, only: [:edit, :update] do
-        patch :revert
+        put :revert
       end
 
       scope module: :calculators do

--- a/spec/requests/site_setting_spec.rb
+++ b/spec/requests/site_setting_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe Account::SiteSettingsController, type: :request do
     end
   end
 
-  describe "PATCH #revert" do
+  describe "PUT #revert" do
     context "with valid params" do
       before { site_setting.update(site_setting_params_new_title) }
 
       it "reverts site setting" do
-        patch revert_account_site_setting_path
+        put revert_account_site_setting_path
 
         expect(response).to redirect_to(edit_account_site_setting_path)
         expect(flash[:notice]).to eq(I18n.t("notifications.site_setting_reverted"))
@@ -74,7 +74,7 @@ RSpec.describe Account::SiteSettingsController, type: :request do
       before { allow(site_setting).to receive(:update).and_return(false) }
 
       it "renders edit page with error message" do
-        patch revert_account_site_setting_path
+        put revert_account_site_setting_path
 
         expect(response).to render_template(:edit)
         expect(response).to be_unprocessable

--- a/spec/requests/site_setting_spec.rb
+++ b/spec/requests/site_setting_spec.rb
@@ -53,20 +53,18 @@ RSpec.describe Account::SiteSettingsController, type: :request do
     end
   end
 
-  describe "GET #revert" do
+  describe "PATCH #revert" do
     include_context :authorize_admin
 
     context "with valid params" do
       let(:site_setting) { SiteSetting.current }
       let(:site_setting_params) { FactoryBot.attributes_for(:site_setting, :custom_setting) }
       let(:site_setting_default_params) { FactoryBot.attributes_for(:site_setting, :with_valid_site_setting) }
-      let(:old_file_name) { "app/assets/images/logo_zerowaste.png" }
-      let(:new_file_name) { "app/assets/images/new_logo_zerowaste.png" }
 
       before { site_setting.update(site_setting_params) }
 
       it "reverts site setting" do
-        post revert_account_site_setting_path
+        patch revert_account_site_setting_path
 
         expect(response).to redirect_to(edit_account_site_setting_path)
         expect(flash[:notice]).to eq(I18n.t("notifications.site_setting_reverted"))

--- a/spec/requests/site_setting_spec.rb
+++ b/spec/requests/site_setting_spec.rb
@@ -1,12 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Account::SiteSettingsController, type: :request do
-  describe "GET edit" do
+  let(:site_setting) { SiteSetting.current }
+  let(:site_setting_params) { attributes_for(:site_setting, :with_valid_site_setting) }
+  let(:site_setting_invalid_params) { attributes_for(:site_setting, :invalid_site_setting) }
+  let(:site_setting_params_new_title) { attributes_for(:site_setting, :new_title) }
+
+  before { allow(SiteSetting).to receive(:current).and_return(site_setting) }
+
+  include_context :authorize_admin
+
+  describe "GET #edit" do
     context "when user is authenticated" do
-      include_context :authorize_admin
-
-      let(:site_setting_params) { FactoryBot.attributes_for(:site_setting, :with_valid_site_setting) }
-
       it "renders the edit template" do
         get edit_account_site_setting_path
 
@@ -17,35 +22,29 @@ RSpec.describe Account::SiteSettingsController, type: :request do
     end
   end
 
-  describe "PATCH update" do
-    include_context :authorize_admin
+  describe "PATCH #update" do
+    before { site_setting.update(site_setting_params) }
 
     context "with valid params" do
-      let(:site_setting_params) { { site_setting: FactoryBot.attributes_for(:site_setting, :with_valid_site_setting) } }
-      let(:site_setting_params_new_title) { { site_setting: FactoryBot.attributes_for(:site_setting, :new_title) } }
-
       it "updates site setting" do
-        patch account_site_setting_path, params: site_setting_params
+        patch account_site_setting_path, params: { site_setting: site_setting_params }
 
         expect(response).to redirect_to(edit_account_site_setting_path)
         expect(flash[:notice]).to eq(I18n.t("notifications.site_setting_updated"))
-        expect(SiteSetting.current).to be_valid
-        expect(SiteSetting.current.favicon.attached?).to be_truthy
+        expect(site_setting).to be_valid
+        expect(site_setting.favicon.attached?).to be_truthy
       end
 
       it "change title" do
         expect do
-          patch account_site_setting_path, params: site_setting_params_new_title
-        end.to change { SiteSetting.current.title }.from("ZeroWaste").to("Test title")
+          patch account_site_setting_path, params: { site_setting: site_setting_params_new_title }
+        end.to change { site_setting.title }.from("ZeroWaste").to("Test title")
       end
     end
 
     context "with invalid params" do
-      let(:site_setting) { SiteSetting.current }
-      let(:site_setting_params) { FactoryBot.attributes_for(:site_setting, :invalid_site_setting) }
-
       it "renders edit page with error message" do
-        patch account_site_setting_path, params: { site_setting: site_setting_params }
+        patch account_site_setting_path, params: { site_setting: site_setting_invalid_params }
 
         expect(response).to render_template(:edit)
         expect(response).to be_unprocessable
@@ -54,14 +53,8 @@ RSpec.describe Account::SiteSettingsController, type: :request do
   end
 
   describe "PATCH #revert" do
-    include_context :authorize_admin
-
     context "with valid params" do
-      let(:site_setting) { SiteSetting.current }
-      let(:site_setting_params) { FactoryBot.attributes_for(:site_setting, :custom_setting) }
-      let(:site_setting_default_params) { FactoryBot.attributes_for(:site_setting, :with_valid_site_setting) }
-
-      before { site_setting.update(site_setting_params) }
+      before { site_setting.update(site_setting_params_new_title) }
 
       it "reverts site setting" do
         patch revert_account_site_setting_path
@@ -69,11 +62,22 @@ RSpec.describe Account::SiteSettingsController, type: :request do
         expect(response).to redirect_to(edit_account_site_setting_path)
         expect(flash[:notice]).to eq(I18n.t("notifications.site_setting_reverted"))
 
-        expect(SiteSetting.current).to be_valid
-        expect(SiteSetting.current.favicon.attached?).to be_truthy
+        expect(site_setting).to be_valid
+        expect(site_setting.favicon.attached?).to be_truthy
 
-        expect(SiteSetting.current.title).to eq(site_setting_default_params[:title])
-        expect(SiteSetting.current.favicon.filename).to eq(site_setting_default_params[:favicon].original_filename)
+        expect(site_setting.title).to eq(site_setting_params[:title])
+        expect(site_setting.favicon.filename).to eq(site_setting_params[:favicon].original_filename)
+      end
+    end
+
+    context "with invalid params" do
+      before { allow(site_setting).to receive(:update).and_return(false) }
+
+      it "renders edit page with error message" do
+        patch revert_account_site_setting_path
+
+        expect(response).to render_template(:edit)
+        expect(response).to be_unprocessable
       end
     end
   end


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #720](https://github.com/ita-social-projects/ZeroWaste/issues/720)


## Code reviewers

- [ ] @loqimean

### Second Level Review

- [x] @obniavko

## Summary of issue

The title and favicon did not revert to their default settings on the 'Site Settings' page.

## Summary of change
1. Fixed 'revert' functionality.
2. Fixed styles.
3. Added transition effect for buttons on the page.
4. Added tests.
5. Changed request method  to 'patch' for account_site_setting_path.

https://github.com/ita-social-projects/ZeroWaste/assets/25872733/1d7db0f2-c15e-4480-9889-f59c4d4c133a


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
