### PR TITLE
Fix/ Gray table background color

### DIFF
--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <% set_meta_tags(title: t(".title")) %>
   <%= search_form_for(@q, url: [:account, :calculators], method: :get, class: "d-flex justify-content-end mb-5") do |f| %>
     <div class="flex">
       <%= f.search_field :name_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -25,7 +25,7 @@
     </thead>
     <tbody class="admin-table-links">
       <% @calculators.each do |calculator| %>
-        <tr class="<%= calculator.preferable ? "table-success" : "table-light" %>">
+        <tr>
           <td><%= calculator.id %></td>
           <td><%= calculator.slug %></td>
           <td><%= calculator.name %></td>

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -1,17 +1,19 @@
 <div class="container">
   <% set_meta_tags(title: t(".title")) %>
-  <%= search_form_for(@q, url: [:account, :calculators], method: :get, class: "d-flex justify-content-end mb-5") do |f| %>
-    <div class="flex">
-      <%= f.search_field :name_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
-      <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
-
-      <span class="mx-2"></span> <!-- Add this span for spacing -->
-      <%= link_to new_account_calculator_path, class: "btn-green px-4 py-2" do %>
+  <div class="row">
+    <div class="col-md-6">
+      <%= search_form_for(@q, url: [:account, :calculators], method: :get, class: "d-flex mb-5") do |f| %>
+        <%= f.search_field :name_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
+        <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
+      <% end %>
+    </div>
+    <div class="col-md-6 text-end">
+      <%= link_to new_account_calculator_path, class: "btn btn-green px-4 py-2" do %>
         <i class="fas fa-plus me-2"></i>
         <span><%= t(".add_calculator_button") %></span>
       <% end %>
     </div>
-  <% end %>
+  </div>
 
   <table aria-label="calculators table" class="table admin-table">
     <thead>

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -26,7 +26,7 @@
     </thead>
     <tbody class="admin-table-links">
       <% @calculators.each do |calculator| %>
-        <tr>
+        <tr class="<%= calculator.preferable ? "table-success" : "text-inherit" %>">
           <td><%= calculator.id %></td>
           <td><%= calculator.slug %></td>
           <td><%= calculator.name %></td>

--- a/app/views/calculators/index.html.erb
+++ b/app/views/calculators/index.html.erb
@@ -4,15 +4,15 @@
       <tr>
         <th scope="col"><%= sort_link(@q, :id, t('.id_column'), default_order: :desc) %></th>
         <th scope="col"><%= sort_link(@q, :name, t('.calculator_name'), default_order: :desc) %></th>
-        <th scope="col"><%= t('.calculator_actions') %></th>
+        <th scope="col" class="text-center"><%= t('.calculator_actions') %></th>
       </tr>
     </thead>
     <tbody class="admin-table-links">
       <% @calculators.each do |calculator| %>
-        <tr class="<%= calculator.preferable ? 'table-success' : 'table-light' %>">
+        <tr>
           <td><%= calculator.id %></td>
           <td><%= calculator.name %></td>
-          <td class="actions">
+          <td class="text-center actions">
             <%= link_to '#', class: 'disabled-link', onclick: 'return false;' do %>
               <i class="mx-2 fa fa-eye"></i>
             <% end %>

--- a/app/views/calculators/index.html.erb
+++ b/app/views/calculators/index.html.erb
@@ -10,7 +10,7 @@
     </thead>
     <tbody class="admin-table-links">
       <% @calculators.each do |calculator| %>
-        <tr>
+        <tr class="<%= calculator.preferable ? "table-success" : "text-inherit" %>">
           <td><%= calculator.id %></td>
           <td><%= calculator.name %></td>
           <td class="text-center actions">

--- a/app/views/calculators/index.html.erb
+++ b/app/views/calculators/index.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <% set_meta_tags(title: t(".title")) %>
   <table aria-label="public calculators table" class="table admin-table">
     <thead>
       <tr>


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #682](https://github.com/ita-social-projects/ZeroWaste/issues/682)

## Code reviewers

- [ ] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

Gray background color in the table on the "Calculators" page.

## Summary of change

Removed gray background color.

![Gray1](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/3e2ba707-4d5a-4f55-ae56-665c89274448)

![Gray2](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/e4418a00-d5c9-440c-9771-781d718d1ae1)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions