### PR TITLE
Add a Search Bar to the Messages page

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -21,4 +21,8 @@ class Message < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "email", "id", "message", "title", "updated_at"]
   end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/views/account/messages/index.html.erb
+++ b/app/views/account/messages/index.html.erb
@@ -1,4 +1,12 @@
 <div class="container home">
+  <% set_meta_tags(title: t(".title")) %>
+  <%= search_form_for(@q, url: [:account, :messages], method: :get, class: "d-flex justify-content-end mb-5") do |f| %>
+    <div class="flex">
+      <%= f.search_field :title_or_email_or_message_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
+      <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
+    </div>
+  <% end %>
+
   <table aria-label="messages table" class="table admin-table">
     <caption class="sr-only">This table displays a list of messages.</caption>
     <thead>

--- a/app/views/account/messages/index.html.erb
+++ b/app/views/account/messages/index.html.erb
@@ -1,11 +1,11 @@
-<div class="container home">
+<div class="container">
   <% set_meta_tags(title: t(".title")) %>
-  <%= search_form_for(@q, url: [:account, :messages], method: :get, class: "d-flex justify-content-end mb-5") do |f| %>
-    <div class="flex">
-      <%= f.search_field :title_or_email_or_message_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
-      <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
-    </div>
-  <% end %>
+    <div class="col-md-6">
+      <%= search_form_for(@q, url: [:account, :messages], method: :get, class: "d-flex mb-5") do |f| %>
+        <%= f.search_field :title_or_email_or_message_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
+        <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
+      <% end %>
+  </div>
 
   <table aria-label="messages table" class="table admin-table">
     <caption class="sr-only">This table displays a list of messages.</caption>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -181,6 +181,8 @@ en:
         update: "Update"
     messages:
       index:
+        search_placeholder: "Search"
+        search_button: "Search"
         table:
           title: "Title"
           email: "Email"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -169,6 +169,8 @@ uk:
         update: "Оновити"
     messages:
       index:
+        search_placeholder: "Пошук"
+        search_button: "Шукати"
         table:
           title: "Заголовок"
           email: "Електронна пошта"


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #778](https://github.com/ita-social-projects/ZeroWaste/issues/778)

## Code reviewers

- [ ] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

A "Messages" page should have a Search Bar in order to allow User to search for messages.

## Summary of change

Added a Search Bar to "Messages" page.

![Search](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/6952b38a-d67d-4aa5-8769-ec16a43c6800)

![Search-results](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/44eee728-20c2-434b-8ebf-34f469883963)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions