### PR TITLE
Fix association in Category model for prices

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,7 +13,7 @@
 class Category < ApplicationRecord
   PRIORITY_RANGE = 0..10
 
-  has_one :price, dependent: :destroy
+  has_many :prices, dependent: :destroy
 
   has_many :category_categoryables, dependent: :restrict_with_exception
   has_many :categoryables, through: :category_categoryables


### PR DESCRIPTION
dev
## ZeroWaste project

* https://github.com/ita-social-projects/ZeroWaste/issues/587


## Code reviewers

- [ ] @loqimean 

### Second Level Review

- [ ] @dafeys 

## Summary of issue

Deleting a category only removes one associated price, not all.

## Summary of change

Fixed category deletion issue to properly remove all associated prices. Change association in Category model to for prices to has_many.
