### PR TITLE
Add a Search Bar to the Products page

### DIFF
--- a/app/views/account/products/index.html.erb
+++ b/app/views/account/products/index.html.erb
@@ -2,6 +2,7 @@
   <% set_meta_tags(title: t(".title")) %>
   <div class="row">
     <%= render partial: "account/shared/search_form", locals: {
+      q: @q,
       search_url: account_products_path,
       search_attribute: :title_cont
     } %>

--- a/app/views/account/products/index.html.erb
+++ b/app/views/account/products/index.html.erb
@@ -2,10 +2,10 @@
   <% set_meta_tags(title: t(".title")) %>
   <div class="row">
     <%= render partial: "account/shared/search_form", locals: {
-      q: @q,
-      search_url: account_products_path,
-      search_attribute: :title_cont
-    } %>
+          q: @q,
+          search_url: account_products_path,
+          search_attribute: :title_cont
+        } %>
     <div class="col-md-6 text-end">
       <%= link_to new_account_product_path, class: "btn btn-green px-4 py-2" do %>
         <i class="fas fa-plus me-2"></i>

--- a/app/views/account/products/index.html.erb
+++ b/app/views/account/products/index.html.erb
@@ -6,6 +6,7 @@
           search_url: account_products_path,
           search_attribute: :title_cont
         } %>
+
     <div class="col-md-6 text-end">
       <%= link_to new_account_product_path, class: "btn btn-green px-4 py-2" do %>
         <i class="fas fa-plus me-2"></i>

--- a/app/views/account/products/index.html.erb
+++ b/app/views/account/products/index.html.erb
@@ -1,12 +1,10 @@
 <div class="container">
   <% set_meta_tags(title: t(".title")) %>
   <div class="row">
-    <div class="col-md-6">
-      <%= search_form_for(@q, url: [:account, :products], method: :get, class: "d-flex mb-5") do |f| %>
-        <%= f.search_field :title_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
-        <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
-      <% end %>
-    </div>
+    <%= render partial: "account/shared/search_form", locals: {
+      search_url: account_products_path,
+      search_attribute: :title_cont
+    } %>
     <div class="col-md-6 text-end">
       <%= link_to new_account_product_path, class: "btn btn-green px-4 py-2" do %>
         <i class="fas fa-plus me-2"></i>

--- a/app/views/account/products/index.html.erb
+++ b/app/views/account/products/index.html.erb
@@ -1,9 +1,18 @@
 <div class="container">
-  <div class="mb-5 d-flex justify-content-end">
-    <%= link_to new_account_product_path, class: 'btn-green px-4 py-2' do %>
-      <i class="fa fa-plus me-2"></i>
-      <span><%= t('.add_product_button') %></span>
-    <% end %>
+  <% set_meta_tags(title: t(".title")) %>
+  <div class="row">
+    <div class="col-md-6">
+      <%= search_form_for(@q, url: [:account, :products], method: :get, class: "d-flex mb-5") do |f| %>
+        <%= f.search_field :title_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
+        <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
+      <% end %>
+    </div>
+    <div class="col-md-6 text-end">
+      <%= link_to new_account_product_path, class: "btn btn-green px-4 py-2" do %>
+        <i class="fas fa-plus me-2"></i>
+        <span><%= t(".add_product_button") %></span>
+      <% end %>
+    </div>
   </div>
 
   <table aria-label="products table" class="table admin-table">

--- a/app/views/account/shared/_search_form.html.erb
+++ b/app/views/account/shared/_search_form.html.erb
@@ -1,0 +1,6 @@
+<div class="col-md-6">
+  <%= search_form_for(@q, url: search_url, method: :get, class: "d-flex mb-5") do |f| %>
+    <%= f.search_field search_attribute, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
+    <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
+  <% end %>
+</div>

--- a/app/views/account/shared/_search_form.html.erb
+++ b/app/views/account/shared/_search_form.html.erb
@@ -1,5 +1,5 @@
 <div class="col-md-6">
-  <%= search_form_for(@q, url: search_url, method: :get, class: "d-flex mb-5") do |f| %>
+  <%= search_form_for(q, url: search_url, method: :get, class: "d-flex mb-5") do |f| %>
     <%= f.search_field search_attribute, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
     <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
   <% end %>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -208,11 +208,13 @@ en:
         form:
           create_category_button: "Create category"
     products:
-      table:
-        title: "Title"
-        prices: "Prices"
-        actions: "Actions"
       index:
+        search_placeholder: "Search"
+        search_button: "Search"
+        table:
+          title: "Title"
+          prices: "Prices"
+          actions: "Actions"
         add_product_button: "Add product"
         confirm_delete: "Delete product?"
       show:

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -506,11 +506,11 @@ en:
         product:
           attributes:
             title:
-              blank: can't be blank
-              too_long: too long (maximum %{count} symbols)
-              too_short: too short (minimum %{count} symbols)
-              taken: has already been taken, please choose another one
-              invalid: contains invalid characters
+              blank: "can't be blank"
+              too_long: "is too long (maximum %{count} symbols)"
+              too_short: "is too short (minimum %{count} symbols)"
+              taken: "has already been taken, please choose another one"
+              invalid: "contains invalid characters"
         price:
           attributes:
             sum:

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -209,8 +209,6 @@ en:
           create_category_button: "Create category"
     products:
       index:
-        search_placeholder: "Search"
-        search_button: "Search"
         table:
           title: "Title"
           prices: "Prices"

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -9,4 +9,7 @@ en:
   account:
     shared:
       navigation:
-        donate: "DONATE"
+        donate: "Donate"
+      search_form:
+        search_placeholder: "Search"
+        search_button: "Search"

--- a/config/locales/uk/layouts.yml
+++ b/config/locales/uk/layouts.yml
@@ -11,3 +11,6 @@ uk:
       navigation:
         donate: "Підтримати"
         calculators: "Калькулятори"
+      search_form:
+        search_placeholder: "Пошук"
+        search_button: "Шукати"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -203,8 +203,6 @@ uk:
           create_category_button: "Створити категорію"
     products:
       index:
-        search_placeholder: "Пошук"
-        search_button: "Шукати"
         table:
           title: "Назва"
           prices: "Ціни"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -203,6 +203,8 @@ uk:
           create_category_button: "Створити категорію"
     products:
       index:
+        search_placeholder: "Пошук"
+        search_button: "Шукати"
         table:
           title: "Назва"
           prices: "Ціни"


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #785](https://github.com/ita-social-projects/ZeroWaste/issues/785)
* [Project ticket #805](https://github.com/ita-social-projects/ZeroWaste/issues/805)

## Code reviewers

- [ ] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

A "Products" page should have a Search Bar in order to allow User to search for products.

## Summary of change

Added a Search Bar to "Products" page.

![Search](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/80399d8c-fb97-4cb0-894a-0202364d008a)

![Search-results](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/e15c8941-2d21-4e24-a2ab-42c42204c08f)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions