### PR TITLE
Fix/ Incorrect timezone when message from user is received

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module ZeroWaste
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    config.time_zone = 'Kyiv'
+    config.time_zone = "Kyiv"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.available_locales   = [:en, :uk]
     config.i18n.default_locale      = :en

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module ZeroWaste
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Kyiv'
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.available_locales   = [:en, :uk]
     config.i18n.default_locale      = :en

--- a/spec/features/account/users_spec.rb
+++ b/spec/features/account/users_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "visit admin page", js: true do
-  let(:time_login) { Time.new(2020, 0o1, 0o1).utc }
+  let(:time_login) { Time.new(2020, 0o1, 0o1).in_time_zone("Kyiv") }
   let!(:another_user) do
     create(:user, email: "test1@gmail.com", password: "12345878",
                   last_sign_in_at: time_login)

--- a/spec/lib/users_csv_generator_spec.rb
+++ b/spec/lib/users_csv_generator_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe UsersCsvGenerator do
-  let(:time_login) { Time.new(2020, 0o1, 0o1).utc }
+  let(:time_login) { Time.new(2020, 0o1, 0o1).in_time_zone("Kyiv") }
 
   let(:users) do
     [create(:user, email: "test@gmail.com", first_name: "Han", last_name: "Solo", last_sign_in_at: time_login)]

--- a/spec/requests/account/users_spec.rb
+++ b/spec/requests/account/users_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Account::UsersController", type: :request do
       expect(csv_content).to match(user.email)
       expect(csv_content).to match(user.first_name)
       expect(csv_content).to match(user.last_name)
-      expect(csv_content).to match(/#{Regexp.escape(user.last_sign_in_at.strftime("%Y-%m-%d %H:%M:%S %z"))}/)
+      expect(csv_content).to include(user.last_sign_in_at.to_s)
     end
 
     it "returns the expected attributes" do

--- a/spec/requests/account/users_spec.rb
+++ b/spec/requests/account/users_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Account::UsersController", type: :request do
       expect(csv_content).to match(user.email)
       expect(csv_content).to match(user.first_name)
       expect(csv_content).to match(user.last_name)
-      expect(csv_content).to match(user.last_sign_in_at.to_s)
+      expect(csv_content).to match(/#{Regexp.escape(user.last_sign_in_at.strftime("%Y-%m-%d %H:%M:%S %z"))}/)
     end
 
     it "returns the expected attributes" do


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #782](https://github.com/ita-social-projects/ZeroWaste/issues/782)

## Code reviewers

- [ ] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

Time in 'Messages' is different from current time

## Summary of change

Changed timezone to Kyiv timezone

![Time1](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/0ed25b0e-263a-4fe3-a25f-ee760332c22e)

![Time2](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/f3e234e2-dfd2-4c31-951c-3c070e5574ab)

![Time3](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/decad0a6-1b03-4958-9f99-ee87ed9ecb2b)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions