### PR TITLE
Fix/ Slug transliteration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "jquery-rails"
 # gem 'bcrypt', '~> 3.1.7'
 gem "acts_as_singleton"
 gem "friendly_id", "~> 5.4.0"
+gem 'babosa'
 
 gem "dentaku", "~> 3.1"
 gem "it"

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "jquery-rails"
 # gem 'bcrypt', '~> 3.1.7'
 gem "acts_as_singleton"
 gem "friendly_id", "~> 5.4.0"
-gem 'babosa'
+gem "babosa"
 
 gem "dentaku", "~> 3.1"
 gem "it"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.15.0)
       execjs (~> 2)
+    babosa (2.0.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.0.2)
@@ -605,6 +606,7 @@ DEPENDENCIES
   acts_as_singleton
   annotate
   any_login
+  babosa
   bigdecimal (= 3.0.2)
   bootsnap (>= 1.4.4)
   bootstrap

--- a/app/models/calculator.rb
+++ b/app/models/calculator.rb
@@ -18,6 +18,7 @@
 #  index_calculators_on_slug  (slug) UNIQUE
 #  index_calculators_on_uuid  (uuid) UNIQUE
 #
+
 class Calculator < ApplicationRecord
   extend FriendlyId
 
@@ -44,6 +45,10 @@ class Calculator < ApplicationRecord
                               "%#{search&.strip}%"
                             )
                           }
+
+  def normalize_friendly_id(input)
+    input.to_slug.transliterate(:ukrainian).normalize.to_s
+  end
 
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "id", "name", "preferable", "slug", "updated_at", "uuid"]

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -1,12 +1,10 @@
 <div class="container">
   <% set_meta_tags(title: t(".title")) %>
   <div class="row">
-    <div class="col-md-6">
-      <%= search_form_for(@q, url: [:account, :calculators], method: :get, class: "d-flex mb-5") do |f| %>
-        <%= f.search_field :name_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
-        <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
-      <% end %>
-    </div>
+    <%= render partial: "account/shared/search_form", locals: {
+      search_url: account_calculators_path,
+      search_attribute: :name_cont
+    } %>
     <div class="col-md-6 text-end">
       <%= link_to new_account_calculator_path, class: "btn btn-green px-4 py-2" do %>
         <i class="fas fa-plus me-2"></i>

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -2,6 +2,7 @@
   <% set_meta_tags(title: t(".title")) %>
   <div class="row">
     <%= render partial: "account/shared/search_form", locals: {
+      q: @q,
       search_url: account_calculators_path,
       search_attribute: :name_cont
     } %>

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -1,23 +1,26 @@
 <div class="container">
-  <%= search_form_for(@q, url: [:account, :calculators], method: :get, class: "d-flex justify-content-end mb-5") do |f| %>
-    <div class="flex">
-      <%= f.search_field :name_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
-      <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
-
-      <span class="mx-2"></span>
-      <%= link_to new_account_calculator_path, class: "btn-green px-4 py-2" do %>
+  <% set_meta_tags(title: t(".title")) %>
+  <div class="row">
+    <div class="col-md-6">
+      <%= search_form_for(@q, url: [:account, :calculators], method: :get, class: "d-flex mb-5") do |f| %>
+        <%= f.search_field :name_cont, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
+        <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
+      <% end %>
+    </div>
+    <div class="col-md-6 text-end">
+      <%= link_to new_account_calculator_path, class: "btn btn-green px-4 py-2" do %>
         <i class="fas fa-plus me-2"></i>
         <span><%= t(".add_calculator_button") %></span>
       <% end %>
     </div>
-  <% end %>
+  </div>
 
   <table aria-label="calculators table" class="table admin-table">
     <thead>
       <tr>
         <th scope="col"><%= sort_link(@q, :id, "#", default_order: :desc) %></th>
-        <th scope="col"><%= sort_link(@q, :slug, t(".table.calculator_slug"), default_order: :desc) %></th>
         <th scope="col"><%= sort_link(@q, :name, t(".table.calculator_name"), default_order: :desc) %></th>
+        <th scope="col"><%= sort_link(@q, :slug, t(".table.calculator_slug"), default_order: :desc) %></th>
         <th scope="col" class="text-center"><%= t('.table.show') %></th>
         <th scope="col" class="text-center"><%= t('.table.edit') %></th>
         <th scope="col" class="text-center"><%= t('.table.delete') %></th>
@@ -25,10 +28,10 @@
     </thead>
     <tbody class="admin-table-links">
       <% @calculators.each do |calculator| %>
-        <tr class="<%= calculator.preferable ? "table-success" : "table-light" %>">
+        <tr class="<%= calculator.preferable ? "table-success" : "text-inherit" %>">
           <td><%= calculator.id %></td>
-          <td><%= calculator.slug %></td>
           <td><%= calculator.name %></td>
+          <td><%= calculator.slug %></td>
           <td class="text-center"><%= link_to icon('fa-solid', 'eye'), account_calculator_path(slug: calculator) %></td>
           <td class="text-center"><%= link_to icon('fa-solid', 'edit'), edit_account_calculator_path(slug: calculator) %></td>
           <td class="text-center">

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <% set_meta_tags(title: t(".title")) %>
   <div class="row">
-    <%= render partial: "account/shared/search_form", locals: {
+<%= render partial: "account/shared/search_form", locals: {
       q: @q,
       search_url: account_calculators_path,
       search_attribute: :name_cont

--- a/app/views/account/shared/_search_form.html.erb
+++ b/app/views/account/shared/_search_form.html.erb
@@ -1,0 +1,6 @@
+<div class="col-md-6">
+  <%= search_form_for(@q, url: search_url, method: :get, class: "d-flex mb-5") do |f| %>
+    <%= f.search_field search_attribute, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
+    <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
+  <% end %>
+</div>

--- a/app/views/account/shared/_search_form.html.erb
+++ b/app/views/account/shared/_search_form.html.erb
@@ -1,5 +1,5 @@
 <div class="col-md-6">
-  <%= search_form_for(@q, url: search_url, method: :get, class: "d-flex mb-5") do |f| %>
+  <%= search_form_for(q, url: search_url, method: :get, class: "d-flex mb-5") do |f| %>
     <%= f.search_field search_attribute, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
     <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
   <% end %>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -292,8 +292,6 @@ en:
         confirm_default: "Are you sure you want to revert the title and favicon to their default settings?"
     calculators:
       index:
-        search_placeholder: "Search"
-        search_button: "Search"
         add_calculator_button: "Add calculator"
         confirm_delete: "Are you sure you want to delete calculator?"
         table:

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -9,4 +9,7 @@ en:
   account:
     shared:
       navigation:
-        donate: "DONATE"
+        donate: "Donate"
+      search_form:
+        search_placeholder: "Search"
+        search_button: "Search"

--- a/config/locales/uk/layouts.yml
+++ b/config/locales/uk/layouts.yml
@@ -11,3 +11,6 @@ uk:
       navigation:
         donate: "Підтримати"
         calculators: "Калькулятори"
+      search_form:
+        search_placeholder: "Пошук"
+        search_button: "Шукати"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -283,8 +283,6 @@ uk:
           unblocked_label: "Розблокований"
     calculators:
       index:
-        search_placeholder: "Пошук"
-        search_button: "Шукати"
         add_calculator_button: "Додати калькулятор"
         confirm_delete: "Ви справді хочете видалити калькулятор?"
         table:


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #791](https://github.com/ita-social-projects/ZeroWaste/issues/791)

## Code reviewers

- [ ] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

Transliteration of slugs is incorrect.

## Summary of change

1. Fixed transliteration.
2. Changed column order of Calculators table ('Name' to 'Slug' instead of 'Slug' to 'Name', because 'Name' has higher priority).

![Slug](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/f2cc7ae8-e45c-4a4a-80d6-71fec9b7499e)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions