### PR TITLE
[Admin/History] Replace 'Back' button with 'up' button.

### DIFF
--- a/app/views/account/histories/index.html.erb
+++ b/app/views/account/histories/index.html.erb
@@ -37,6 +37,6 @@
 
 <div class="container py-2">
   <div class="px-4 py-2 my-4 btn-grey w-min">
-    <%= link_to t('.back_link'), account_users_path %>
+    <%= link_to t('.back_link'), account_histories_path %>
   </div>
 </div>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -381,7 +381,7 @@ en:
     histories:
       index:
         history_title: "History"
-        back_link: "Back"
+        back_link: "Up"
         table:
           version_created_at: "Version creation date"
           event_ID: "Event ID"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -387,7 +387,7 @@ uk:
     histories:
       index:
         history_title: "Історія"
-        back_link: "Назад"
+        back_link: "Наверх"
         table:
           version_created_at: "Дата створення версії"
           event_ID: "ID події"


### PR DESCRIPTION
dev
* resolves  #809 

## Code reviewers

- [ ] @kisiohlova 
- [ ] @loqimean 

## Summary of issue

The 'Back' button on the 'History' page incorrectly directs to the 'Users' page when clicked. 
Instead of 'Back' button 'Up' button should be created.

## Summary of change

 - Replaced the 'Back' button with an 'Up' button:
- 'Up' button  turn the page up.

https://github.com/ita-social-projects/ZeroWaste/assets/83007830/c4acb0c5-2ab4-4f46-878d-fd1331f4d067

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
