### PR TITLE
Add titles using meta-tag gem

### DIFF
--- a/app/views/account/app_configs/edit.html.erb
+++ b/app/views/account/app_configs/edit.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags(title: t(".title")) %>
+
 <div class="container">
   <h2 class="text-center"><%= t('.diapers_calculator_config') %></h2>
 </div>

--- a/app/views/account/histories/index.html.erb
+++ b/app/views/account/histories/index.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags(title: t(".title")) %>
+
 <div class="container p-3 bg-light">
   <h2 class="p-3 text-center"><%= t('.history_title') %></h2>
   <table aria-label="history table" class="table table-striped table-bordered">

--- a/app/views/account/products/index.html.erb
+++ b/app/views/account/products/index.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <% set_meta_tags(title: t(".title")) %>
   <div class="mb-5 d-flex justify-content-end">
     <%= link_to new_account_product_path, class: 'btn-green px-4 py-2' do %>
       <i class="fa fa-plus me-2"></i>

--- a/app/views/account/site_settings/edit.html.erb
+++ b/app/views/account/site_settings/edit.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags(title: t(".title")) %>
+
 <fieldset class="bordered">
   <legend class="admin-legend">
     <%= t(".site_settings") %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags(title: t(".title")) %>
+
 <div class="position-block">
   <div class="card">
     <div class="p-4 card-block">
@@ -24,8 +26,8 @@
 
         <div class="flex-row-reverse flex-wrap flex gap-3">
           <%= f.submit t(".form.sign_up_button"), class: "btn btn-primary" %>
-          
-          <%= render "devise/shared/links" %>          
+
+          <%= render "devise/shared/links" %>
         </div>
       <% end %>
     </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags(title: t(".title")) %>
+
 <div class="position-block">
   <div class="card">
     <div class="p-4 card-block">

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags(title: t(".title")) %>
+
 <div class="position-block">
   <div class="card">
     <div class="card-block p-4">
@@ -8,9 +10,9 @@
         <%= form_with model: @message do |form| %>
           <div class="title">
             <div class="text">
-              <%= t('.title') %>
+              <%= t('.title1') %>
             </div>
-            <%= form.text_field :title, class:'form-control', placeholder: t('.title_hint'), minlength: "5", required: true %>
+            <%= form.text_field :title1, class:'form-control', placeholder: t('.title_hint'), minlength: "5", required: true %>
           </div>
           <div class="email">
             <div class="text">

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -39,6 +39,8 @@ en:
     revert: "Revert"
     back: "Back"
   calculators:
+    index:
+      title: "Calculators"
     new_calculator:
       form:
         description: "Child’s age:"
@@ -135,10 +137,11 @@ en:
       thanks: "Thanks for joining and have a great day!"
   messages:
     new:
+      title: "Contact Us"
       contact_us_header: "Contact us"
       email: "Email"
       message: "Message"
-      title: "Title"
+      title1: "Title"
       send: "Send"
       title_hint: "title (min 5 characters)"
       message_hint: "Your message (min 20 characters)"
@@ -171,6 +174,7 @@ en:
         change_password_button: "Change password"
     app_configs:
       edit:
+        title: "App Config"
         diapers_calculator_config: "Diapers calculator configuration"
         first_period: "First period"
         second_period: "Second period"
@@ -184,10 +188,11 @@ en:
         update: "Update"
     messages:
       index:
+        title: "Messages"
         search_placeholder: "Search"
         search_button: "Search"
         table:
-          title: "Title"
+          title1: "Title"
           email: "Email"
           message: "Message"
           show_more: "Show more"
@@ -200,6 +205,7 @@ en:
           time_col: "Date"
     categories:
       index:
+        title: "Categories"
         search_placeholder: "Search"
         search_button: "Search"
         add_category_button: "Add category"
@@ -216,6 +222,7 @@ en:
         prices: "Prices"
         actions: "Actions"
       index:
+        title: "Products"
         add_product_button: "Add product"
         confirm_delete: "Delete product?"
       show:
@@ -287,6 +294,7 @@ en:
         button: "Back"
     site_settings:
       edit:
+        title: "Site Settings"
         site_settings: "Site settings"
         site_features: "Site features"
         dev_features: "Development features"
@@ -295,6 +303,7 @@ en:
         confirm_default: "Are you sure you want to revert the title and favicon to their default settings?"
     calculators:
       index:
+        title: "Calculators"
         search_placeholder: "Search"
         search_button: "Search"
         add_calculator_button: "Add calculator"
@@ -382,6 +391,7 @@ en:
         email_label: "Email"
     histories:
       index:
+        title: "History"
         history_title: "History"
         back_link: "Back"
         table:
@@ -407,6 +417,7 @@ en:
         change_password_button: "Change my password"
     sessions:
       new:
+        title: "Log In"
         log_in: "Log in"
     shared:
       links:
@@ -417,6 +428,7 @@ en:
         google_sign_in: "Sign in with Google"
     registrations:
       new:
+        title: "Sign Up"
         sign_up_header: "Sign Up"
         form:
           email_label: "Email"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -8,6 +8,8 @@ uk:
     revert: "Скинути"
     back: "Назад"
   calculators:
+    index:
+      title: "Калькулятори"
     new_calculator:
       form:
         description: "Вік дитини:"
@@ -122,10 +124,11 @@ uk:
       thanks: "Дякуємо за приєднання та бажаємо гарного дня!"
   messages:
     new:
+      title: "Зв'яжіться з нами"
       contact_us_header: "Зв'яжіться з нами"
       email: "Електронна пошта"
       message: "Повідомлення"
-      title: "Заголовок"
+      title1: "Заголовок"
       send: "Надіслати"
       title_hint: "Заголовок (мінімум 5 символів)"
       message_hint: "Напишіть ваше повідомлення тут (мінімум 20 символів)"
@@ -159,6 +162,7 @@ uk:
         change_password_button: "Змінити пароль"
     app_configs:
       edit:
+        title: "Налаштування"
         diapers_calculator_config: "Налаштування калькулятора підгузків"
         first_period: "Перший період"
         second_period: "Другий період"
@@ -172,6 +176,7 @@ uk:
         update: "Оновити"
     messages:
       index:
+        title: "Повідомлення"
         search_placeholder: "Пошук"
         search_button: "Шукати"
         table:
@@ -188,6 +193,7 @@ uk:
           time_col: "Дата"
     categories:
       index:
+        title: "Категорії"
         search_placeholder: "Пошук"
         search_button: "Шукати"
         table:
@@ -206,6 +212,7 @@ uk:
           create_category_button: "Створити категорію"
     products:
       index:
+        title: "Продукти"
         table:
           title: "Назва"
           prices: "Ціни"
@@ -286,6 +293,7 @@ uk:
           unblocked_label: "Розблокований"
     calculators:
       index:
+        title: "Калькулятори"
         search_placeholder: "Пошук"
         search_button: "Шукати"
         add_calculator_button: "Додати калькулятор"
@@ -315,6 +323,7 @@ uk:
         error: "помилки"
     site_settings:
       edit:
+        title: "Налаштування сайту"
         site_settings: "Налаштування сайту"
         site_features: "Особливості сайту"
         rails_db_description: "Доступ до бази даних (лише перегляд)"
@@ -388,6 +397,7 @@ uk:
         email_label: "Електронна пошта"
     histories:
       index:
+        title: "Історія"
         history_title: "Історія"
         back_link: "Назад"
         table:
@@ -413,6 +423,7 @@ uk:
         change_password_button: "Змінити пароль"
     sessions:
       new:
+        title: "Увійти"
         log_in: "Увійти"
     shared:
       links:
@@ -423,6 +434,7 @@ uk:
         google_sign_in: "Увійти через Google"
     registrations:
       new:
+        title: "Зареєструватися"
         sign_up_header: "Зареєструватися"
         form:
           email_label: "Електронна пошта"


### PR DESCRIPTION
dev
https://github.com/ita-social-projects/ZeroWaste/issues/810

## Code reviewers

- [ ] @logimean


- [ ] @github_username

## Summary of issue

Tab names have different format  on Admin panel

## Summary of change

Add titles to Admin panel using meta-tag gem. Tab names have unified format.
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/e164b7ab-8956-4469-8c2d-fc6fa115b96a)
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/e1a2a870-4bf5-4423-aadb-61e9a0b50c4f)
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/c1d04c55-d319-4667-bdb9-2ae610f404bb)
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/88fef634-73f3-4fd8-ad10-907d920c25cd)


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
