### PR TITLE
814 main page header is not centered

### DIFF
--- a/app/views/account/shared/_navigation.html.erb
+++ b/app/views/account/shared/_navigation.html.erb
@@ -44,7 +44,7 @@
         <%= link_to t(".donate"), "https://zerowastelviv.org.ua/pidtrymaty/", target: "_blank", rel: "noopener", class: "header-btns main-btn btn-outline-green" %>
         <%= link_to t("#{switch_locale_to}"), url_for(locale: switch_locale_to), class: "header-btns main-btn btn-outline-gray" %>
       </div>
-      <div class="h-12 w-12 mt-6 ml-2">
+      <div class="mt-6 ml-2">
         <button data-action="click->burger#toggle" class="admin-menu-burger-button">
           <%= image_tag "icons/burger-menu-lines.svg", class: "block h-8 w-8", "data-burger-target": "iconLines" %>
           <%= image_tag "icons/burger-menu-cross.svg", class: "block h-8 w-8 hidden", "data-burger-target": "iconCross" %>


### PR DESCRIPTION
dev
## Zerowaste project

* [#814 ]


## Code reviewers

- [x] @obniavko 

### Second Level Review

- [ ] @loqimean

## Summary of issue

Centered header of main page
How it was:
<img width="1309" alt="Screenshot 2024-03-14 at 12 06 38" src="https://github.com/ita-social-projects/ZeroWaste/assets/35365419/df5015e7-e157-4586-aeaf-e6a984e6c5c1">

## Summary of change

Delete extra styles
How it is:
<img width="1309" alt="Screenshot 2024-03-14 at 12 07 21" src="https://github.com/ita-social-projects/ZeroWaste/assets/35365419/e213a6d9-8225-4c15-99b0-a44a1f5db9fd">


## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
