### PR TITLE
[Products]: Refactor Forms to Turbo Streams: Fix Translation.

### DIFF
--- a/app/controllers/account/products_controller.rb
+++ b/app/controllers/account/products_controller.rb
@@ -10,16 +10,19 @@ class Account::ProductsController < Account::BaseController
 
   def new
     @product = Product.new
+    @categories = category_collection
   end
 
   def edit
     @product = resource
+    @categories = category_collection
 
     @product.build_unsigned_categories
   end
 
   def create
     @product = Product.new(product_params)
+    @categories = category_collection
 
     if @product.save
       redirect_to account_products_path, notice: t(".created")
@@ -30,6 +33,7 @@ class Account::ProductsController < Account::BaseController
 
   def update
     @product = resource
+    @categories = category_collection
 
     if @product.update(product_params)
       redirect_to account_products_path, notice: t(".updated")
@@ -57,6 +61,10 @@ class Account::ProductsController < Account::BaseController
 
   def collection
     Product.ordered_by_title
+  end
+
+  def category_collection
+    Category.ordered_by_name
   end
 
   def product_params

--- a/app/controllers/account/products_controller.rb
+++ b/app/controllers/account/products_controller.rb
@@ -9,19 +9,19 @@ class Account::ProductsController < Account::BaseController
   end
 
   def new
-    @product = Product.new
+    @product    = Product.new
     @categories = category_collection
   end
 
   def edit
-    @product = resource
+    @product    = resource
     @categories = category_collection
 
     @product.build_unsigned_categories
   end
 
   def create
-    @product = Product.new(product_params)
+    @product    = Product.new(product_params)
     @categories = category_collection
 
     if @product.save
@@ -32,7 +32,7 @@ class Account::ProductsController < Account::BaseController
   end
 
   def update
-    @product = resource
+    @product    = resource
     @categories = category_collection
 
     if @product.update(product_params)

--- a/app/views/account/products/edit.html.erb
+++ b/app/views/account/products/edit.html.erb
@@ -1,28 +1,3 @@
 <div class="container">
-  <%= simple_form_for @product, method: :patch, url: account_product_path, data: { controller: "price-form" } do |f| %>
-    <div class="form-group row">
-      <div class="my-auto col-12 has-float-label">
-        <%= f.input :title, label: t('.title'), class: 'form-control col-sm-11' %>
-        <% if Category.ordered_by_name.exists? %>
-          <%= f.simple_fields_for :prices do |prices_form| %>
-            <div class="checkbox-blocks">
-              <%= check_box_tag prices_form.object.category.name, 1, true, data: { price_form_target: 'checkbox', action: "click->price-form#removePrice click->price-form#togglePrice" }, class: 'me-1' %>
-              <%= label_tag prices_form.object.category.name %>
-              <div class="hidden-sum" data-price-form-target="price" name="<%= prices_form.object.category.name %>">
-                <%= prices_form.input :sum, label: false, input_html: { placeholder: t('.form.sum'), data: { price_form_target: 'priceInput' } } %>
-                <%= prices_form.hidden_field :category_id, value: prices_form.object.category.id %>
-                <%= prices_form.hidden_field :_destroy, data: { price_form_target: 'hiddenField' } %>
-              </div>
-            </div>
-          <% end %>
-        <% end %>
-      </div>
-    </div>
-    <div class="mt-2 button-group d-flex">
-      <%= f.submit t('.form.update_product_button'), class: 'btn btn-green me-2' %>
-      <%= link_to account_products_path, class: 'btn btn-danger d-flex align-items-center justify-content-center' do %>
-        <span class="me-1"><%= t('buttons.cancel') %></span>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render "account/products/partials/edit/form", product: @product %>
 </div>

--- a/app/views/account/products/edit.html.erb
+++ b/app/views/account/products/edit.html.erb
@@ -1,3 +1,3 @@
 <div class="container">
-  <%= render "account/products/partials/edit/form", product: @product %>
+  <%= render "account/products/partials/edit/form", product: @product, categories: @categories %>
 </div>

--- a/app/views/account/products/edit.turbo_stream.erb
+++ b/app/views/account/products/edit.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace(dom_id(@product, :form), partial: "account/products/partials/edit/form", locals: {product: @product}) %>

--- a/app/views/account/products/edit.turbo_stream.erb
+++ b/app/views/account/products/edit.turbo_stream.erb
@@ -1,1 +1,5 @@
-<%= turbo_stream.replace(dom_id(@product, :form), partial: "account/products/partials/edit/form", locals: {product: @product}) %>
+<%= turbo_stream.replace(
+      dom_id(@product, :form),
+      partial: "account/products/partials/edit/form",
+      locals: { product: @product, categories: @categories }
+    ) %>

--- a/app/views/account/products/new.html.erb
+++ b/app/views/account/products/new.html.erb
@@ -1,27 +1,3 @@
 <div class="container">
-  <%= simple_form_for @product, url: account_products_path, data: { controller: "price-form" } do |f| %>
-    <div class="form-group row">
-      <div class="my-auto col-12 has-float-label">
-        <%= f.input :title, label: t(".title"), class: "form-control col-sm-11" %>
-        <% Category.ordered_by_name.each do |category| %>
-          <div class="checkbox-blocks">
-            <%= check_box_tag category.name, 1, false, data: { action: "click->price-form#togglePrice", price_form_target: "checkbox" }, class: "me-1" %>
-            <%= label_tag category.name %>
-            <div class="hidden-sum" data-price-form-target="price" name="<%= category.name %>">
-              <%= f.simple_fields_for :prices, f.object.find_or_build_price_for_category(category) do |prices_form| %>
-                <%= prices_form.input :sum, label: false, input_html: { placeholder: t(".form.sum"), data: { price_form_target: "priceInput" } } %>
-                <%= prices_form.hidden_field :category_id, value: category.id %>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    </div>
-    <div class="mt-2 button-group d-flex">
-      <%= f.submit t(".form.create_product_button"), class: "btn btn-green me-2 w-auto" %>
-      <%= link_to account_products_path, class: "btn btn-danger d-flex align-items-center justify-content-center" do %>
-        <span class="me-1"><%= t("buttons.cancel") %></span>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render "account/products/partials/new/form", product: @product %>
 </div>

--- a/app/views/account/products/new.html.erb
+++ b/app/views/account/products/new.html.erb
@@ -1,3 +1,3 @@
 <div class="container">
-  <%= render "account/products/partials/new/form", product: @product %>
+  <%= render "account/products/partials/new/form", product: @product, categories: @categories %>
 </div>

--- a/app/views/account/products/new.turbo_stream.erb
+++ b/app/views/account/products/new.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace(dom_id(@product, :form), partial: "account/products/partials/new/form", locals: {product: @product}) %>

--- a/app/views/account/products/new.turbo_stream.erb
+++ b/app/views/account/products/new.turbo_stream.erb
@@ -1,1 +1,5 @@
-<%= turbo_stream.replace(dom_id(@product, :form), partial: "account/products/partials/new/form", locals: {product: @product}) %>
+<%= turbo_stream.replace(
+      dom_id(@product, :form),
+      partial: "account/products/partials/new/form",
+      locals: { product: @product, categories: @categories }
+    ) %>

--- a/app/views/account/products/partials/edit/_form.html.erb
+++ b/app/views/account/products/partials/edit/_form.html.erb
@@ -1,0 +1,26 @@
+ <%= simple_form_for @product, method: :patch, url: account_product_path, html: {id: dom_id(product, :form)}, data: { controller: "price-form" } do |f| %>
+    <div class="form-group row">
+      <div class="my-auto col-12 has-float-label">
+        <%= f.input :title, label: t('.title'), class: 'form-control col-sm-11' %>
+        <% if Category.ordered_by_name.exists? %>
+          <%= f.simple_fields_for :prices do |prices_form| %>
+            <div class="checkbox-blocks">
+              <%= check_box_tag prices_form.object.category.name, 1, true, data: { price_form_target: 'checkbox', action: "click->price-form#removePrice click->price-form#togglePrice" }, class: 'me-1' %>
+              <%= label_tag prices_form.object.category.name %>
+              <div class="hidden-sum" data-price-form-target="price" name="<%= prices_form.object.category.name %>">
+                <%= prices_form.input :sum, label: false, input_html: { placeholder: t('.form.sum'), data: { price_form_target: 'priceInput' } } %>
+                <%= prices_form.hidden_field :category_id, value: prices_form.object.category.id %>
+                <%= prices_form.hidden_field :_destroy, data: { price_form_target: 'hiddenField' } %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+    <div class="mt-2 button-group d-flex">
+      <%= f.submit t('.form.update_product_button'), class: 'btn btn-green me-2' %>
+      <%= link_to account_products_path, class: 'btn btn-danger d-flex align-items-center justify-content-center' do %>
+        <span class="me-1"><%= t('buttons.cancel') %></span>
+      <% end %>
+    </div>
+  <% end %>

--- a/app/views/account/products/partials/edit/_form.html.erb
+++ b/app/views/account/products/partials/edit/_form.html.erb
@@ -1,8 +1,8 @@
- <%= simple_form_for @product, method: :patch, url: account_product_path, html: {id: dom_id(product, :form)}, data: { controller: "price-form" } do |f| %>
+ <%= simple_form_for product, method: :patch, url: account_product_path, html: { id: dom_id(product, :form) }, data: { controller: "price-form" } do |f| %>
     <div class="form-group row">
       <div class="my-auto col-12 has-float-label">
         <%= f.input :title, label: t('.title'), class: 'form-control col-sm-11' %>
-        <% if Category.ordered_by_name.exists? %>
+        <% if categories.exists? %>
           <%= f.simple_fields_for :prices do |prices_form| %>
             <div class="checkbox-blocks">
               <%= check_box_tag prices_form.object.category.name, 1, true, data: { price_form_target: 'checkbox', action: "click->price-form#removePrice click->price-form#togglePrice" }, class: 'me-1' %>

--- a/app/views/account/products/partials/new/_form.html.erb
+++ b/app/views/account/products/partials/new/_form.html.erb
@@ -1,0 +1,25 @@
+<%= simple_form_for product, url: account_products_path, html: {id: dom_id(product, :form)},  data: { controller: "price-form" } do |f| %>
+  <div class="form-group row">
+    <div class="my-auto col-12 has-float-label">
+      <%= f.input :title, label: t(".title"), class: "form-control col-sm-11" %>
+      <% Category.ordered_by_name.each do |category| %>
+        <div class="checkbox-blocks">
+          <%= check_box_tag category.name, 1, false, data: { action: "click->price-form#togglePrice", price_form_target: "checkbox" }, class: "me-1" %>
+          <%= label_tag category.name %>
+          <div class="hidden-sum" data-price-form-target="price" name="<%= category.name %>">
+            <%= f.simple_fields_for :prices, f.object.find_or_build_price_for_category(category) do |prices_form| %>
+              <%= prices_form.input :sum, label: false, input_html: { placeholder: t(".form.sum"), data: { price_form_target: "priceInput" } } %>
+              <%= prices_form.hidden_field :category_id, value: category.id %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <div class="mt-2 button-group d-flex">
+    <%= f.submit t(".form.create_product_button"), class: "btn btn-green me-2 w-auto" %>
+    <%= link_to account_products_path, class: "btn btn-danger d-flex align-items-center justify-content-center" do %>
+      <span class="me-1"><%= t("buttons.cancel") %></span>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/account/products/partials/new/_form.html.erb
+++ b/app/views/account/products/partials/new/_form.html.erb
@@ -1,8 +1,8 @@
-<%= simple_form_for product, url: account_products_path, html: {id: dom_id(product, :form)},  data: { controller: "price-form" } do |f| %>
+<%= simple_form_for product, url: account_products_path, html: { id: dom_id(product, :form) },  data: { controller: "price-form" } do |f| %>
   <div class="form-group row">
     <div class="my-auto col-12 has-float-label">
       <%= f.input :title, label: t(".title"), class: "form-control col-sm-11" %>
-      <% Category.ordered_by_name.each do |category| %>
+      <% categories.each do |category| %>
         <div class="checkbox-blocks">
           <%= check_box_tag category.name, 1, false, data: { action: "click->price-form#togglePrice", price_form_target: "checkbox" }, class: "me-1" %>
           <%= label_tag category.name %>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -213,16 +213,19 @@ en:
         confirm_delete: "Delete product?"
       show:
         confirm_delete: "Delete product?"
-      edit:
-        title: "Title"
-        form:
-          sum: "Sum"
-          update_product_button: "Update product"
-      new:
-        title: "Title"
-        form:
-          sum: "Sum"
-          create_product_button: "Create product"
+      partials:
+        new:
+          form:
+            title: "Title"
+            form:
+              sum: "Sum"
+              create_product_button: "Create product"
+        edit:
+          form:
+            title: "Title"
+            form:
+              sum: "Sum"
+              update_product_button: "Update product"
       created: "A product was successfully created"
       updated: "A product was successfully updated"
       deleted: "A product was successfully deleted"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -221,16 +221,19 @@ uk:
           prices: "Ціни"
           actions: "Дії"
         confirm_delete: "Видалити продукт?"
-      edit:
-        title: "Назва"
-        form:
-          sum: "Сума"
-          update_product_button: "Оновити продукт"
-      new:
-        title: "Назва"
-        form:
-          sum: "Сума"
-          create_product_button: "Створити продукт"
+      partials:
+        new:
+          form:
+            title: "Назва"
+            form:
+              sum: "Сума"
+              create_product_button: "Створити продукт"
+        edit:
+          form:
+            title: "Назва"
+            form:
+              sum: "Сума"
+              update_product_button: "Оновити продукт"
       created: "Продукт був успішно створений"
       updated: "Продукт був успішно оновлений"
       deleted: "Продукт був успішно видалений"


### PR DESCRIPTION
dev
* resolves  #723 

## Code reviewers

- [ ] @dafeys 
- [ ] @loqimean 

## Summary of issue

After switching the language, the Admin is returned back to the page with the list of products instead of observing the translation as expected.

## Summary of change
- Created form partials for updating and creating the product.
- Rewrote the formsinto Turbo Stream format.
- Refactored locale values for correct translation.

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
