### PR TITLE
Fix/ Hover tranisition time

### DIFF
--- a/app/assets/stylesheets/pages/calculator.scss
+++ b/app/assets/stylesheets/pages/calculator.scss
@@ -14,7 +14,7 @@
   font-weight: 400;
   font-family: "Nunito", sans-serif;
   font-style: normal;
-  transition: transform 0.5s linear;
+  transition: transform 0.5s ease-in-out;
   max-width: 300px;
 }
 
@@ -177,6 +177,7 @@
   }
   &:hover {
     background-color: $matte_lime_green;
+    transition: background-color 0.5s ease-in-out;
   }
 }
 


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #833](https://github.com/ita-social-projects/ZeroWaste/issues/833)

## Code reviewers

- [ ] @Natali-Kotelnitska 
- [ ] @loqimean 

## Summary of issue

'_Calculate_' button changes its color from green to dark green in 0.5 sec, while '_How to use less_' button changes its color from green to dark green instantly.

## Summary of change

Changed transition time for '_How to use less_' button

![Hover](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/d2cf1797-d9d4-4c97-be13-58482747983b)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all convention