### PR TITLE
Fix/ Remove ability to edit calculator slug

### DIFF
--- a/app/models/calculator.rb
+++ b/app/models/calculator.rb
@@ -22,7 +22,7 @@
 class Calculator < ApplicationRecord
   extend FriendlyId
 
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: :sequentially_slugged
 
   has_paper_trail
 

--- a/app/views/account/calculators/edit.html.erb
+++ b/app/views/account/calculators/edit.html.erb
@@ -5,9 +5,6 @@
         <%= f.input :name, class: 'form-control', required: true %>
       </div>
       <div class="my-auto col-4 has-float-label">
-        <%= f.input :slug, class: 'form-control', required: true %>
-      </div>
-      <div class="my-auto col-4 has-float-label">
         <%= f.input :preferable, class: 'form-control' %>
       </div>
     </div>


### PR DESCRIPTION
dev
## ZeroWaste project

* [Project ticket #822](https://github.com/ita-social-projects/ZeroWaste/issues/822)

## Code reviewers

- [x] @Natali-Kotelnitska 
- [ ] @loqimean 

## Summary of issue

The ability to edit the slug by the Admin user should be removed as the slug is created once together with the calculator and shouldn't be changed after that (**for SEO purposes**)

## Summary of change

1. Removed ability to edit slug;
2. Slugs are unique and incrementing now.

![Slug](https://github.com/ita-social-projects/ZeroWaste/assets/108181313/3db00620-d914-475a-b431-781c110802f0)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all convention