### PR TITLE
Fix Session Timeout Message Duplication

### DIFF
--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,3 +1,3 @@
-<% flash.each do |message_type, message| %>
+<% flash.to_h.excluding("timedout").each do |message_type, message| %>
   <%= turbo_stream.toast(message, background: message_type) if message.is_a? String %>
 <% end %>

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,3 +1,4 @@
 <% flash.each do |message_type, message| %>
+  <% next if message_type == 'timedout' %>
   <%= turbo_stream.toast(message, background: message_type) %>
 <% end %>

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,4 +1,3 @@
 <% flash.each do |message_type, message| %>
-  <% next unless message.is_a? String %>
-  <%= turbo_stream.toast(message, background: message_type) %>
+  <%= turbo_stream.toast(message, background: message_type) if message.is_a? String %>
 <% end %>

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,3 +1,3 @@
-<% flash.to_h.excluding("timedout").each do |message_type, message| %>
+<% flash.to_h.except("timedout").each do |message_type, message| %>
   <%= turbo_stream.toast(message, background: message_type) if message.is_a? String %>
 <% end %>

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,4 +1,4 @@
 <% flash.each do |message_type, message| %>
-  <% next if message_type == 'timedout' %>
+  <% next unless message.is_a? String %>
   <%= turbo_stream.toast(message, background: message_type) %>
 <% end %>


### PR DESCRIPTION
dev

* resolves #789 

## Code reviewers

- [ ] @loqimean 
- [x] @obniavko 

## Summary of issue

There is currently an issue where two different warning messages, 'true' and "Your session expired. Please sign in again to continue", are appearing after non-working time when logged in. This inconsistency in warning messages needs to be resolved.

#### flash messages (before)
![image](https://github.com/ita-social-projects/ZeroWaste/assets/145603083/dad7bbec-09db-4033-b78d-f93e240c25ad)

## Summary of change

The issue was fixed by modifying the flash message iteration in the view. The 'timedout' message type is now skipped, preventing the 'true' message from being displayed.

#### flash message (after changes)
![Знімок екрана (608)](https://github.com/ita-social-projects/ZeroWaste/assets/83007830/a7830488-9936-4053-8480-0348f95133b9)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
