### PR TITLE
Fix meta title on Products Page

### DIFF
--- a/app/views/account/products/index.html.erb
+++ b/app/views/account/products/index.html.erb
@@ -1,7 +1,6 @@
 <% set_meta_tags(title: t(".meta-title")) %>
 
 <div class="container">
-  <% set_meta_tags(title: t(".title")) %>
   <div class="row">
     <%= render partial: "account/shared/search_form", locals: {
           q: @q,


### PR DESCRIPTION
dev
* [Project ticket #810](https://github.com/ita-social-projects/ZeroWaste/issues/810)
## Code reviewers

- [ ] @loqimean 

### Second Level Review

- [x] @obniavko 

## Summary of issue

Tab names have different format  Admin panel.

## Summary of change

Added titles to Products Page  using meta-tag gem. Tab names have unified format.
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/e394b918-5eb5-4865-ac36-d71189e30d56)


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
