### PR TITLE
Refactor diapers error messages validations

### DIFF
--- a/app/models/diapers_period.rb
+++ b/app/models/diapers_period.rb
@@ -14,21 +14,22 @@
 class DiapersPeriod < ApplicationRecord
   belongs_to :category
 
-  validates :price,
-            presence: true,
-            numericality: { greater_than_or_equal_to: 0, less_than: 1000 }
+  validates :price, presence: true
+  validates :price, numericality: { greater_than_or_equal_to: 0, less_than: 1000 }, allow_blank: true
 
   validates :period_start,
             presence: true,
             numericality: { only_integer: true, greater_than_or_equal_to: 1 }
 
+  validates :period_end, presence: true
   validates :period_end,
-            presence: true,
-            numericality: { only_integer: true, greater_than: :period_start, less_than_or_equal_to: 30 }
+            numericality: { only_integer: true, greater_than: :period_start, less_than_or_equal_to: 30 },
+            allow_blank: true
 
+  validates :usage_amount, presence: true
   validates :usage_amount,
-            presence: true,
-            numericality: { greater_than_or_equal_to: 0, less_than: 100 }
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 100 },
+            allow_blank: true
 
   scope :ordered, -> { order(:id) }
 

--- a/app/models/diapers_period.rb
+++ b/app/models/diapers_period.rb
@@ -16,7 +16,7 @@ class DiapersPeriod < ApplicationRecord
 
   validates :price,
             presence: true,
-            numericality: { greater_than_or_equal_to: 0 }
+            numericality: { greater_than_or_equal_to: 0, less_than: 1000 }
 
   validates :period_start,
             presence: true,
@@ -28,7 +28,7 @@ class DiapersPeriod < ApplicationRecord
 
   validates :usage_amount,
             presence: true,
-            numericality: { greater_than_or_equal_to: 0 }
+            numericality: { greater_than_or_equal_to: 0, less_than: 100 }
 
   scope :ordered, -> { order(:id) }
 

--- a/app/views/account/diapers_periods/partials/new/_form.html.erb
+++ b/app/views/account/diapers_periods/partials/new/_form.html.erb
@@ -4,13 +4,14 @@
     <div class="group-wrapper">
       <div class="input-field-wrapper" title="<%= t(".cannot_edit_start_period") %>">
         <%= form.input :period_start,
-              label: t(".period_start"),
-              input_html: { value: period.period_start, disabled: true, style: "cursor: not-allowed" } %>
+              input_html: { value: period.period_start, disabled: true, style: "cursor: not-allowed" },
+              label: t(".period_start")%>
         <%= form.hidden_field :period_start, value: period.period_start %>
       </div>
 
       <div class="input-field-wrapper">
         <%= form.input :period_end,
+              input_html: { min: period.period_start + 1, step: 1 },
               label: t(".period_end") %>
       </div>
     </div>
@@ -18,11 +19,13 @@
     <div class="mt-4 group-wrapper">
       <div class="input-field-wrapper">
         <%= form.input :usage_amount,
+              input_html: { min: 0, step: 1 },
               label: t(".usage_amount")%>
       </div>
 
       <div class="input-field-wrapper">
         <%= form.input :price,
+              input_html: { min: 0, step: 0.01 },
               label: t(".price")%>
       </div>
     </div>

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -610,7 +610,7 @@ uk:
         diapers_period:
           attributes:
             price:
-              blank: "не може бути пустою"
+              blank: "не може бути порожньою"
         product:
           attributes:
             title:


### PR DESCRIPTION
dev
- #846 
- #850 
- #853 

## Code reviewers
[ ] @loqimean 
[ ] @Natali-Kotelnitska 

## Summary of issue
- "Content missing" error is appeared in Diapers Categories container when a large value is entered in the "Usage Amount" field
- "can't be blank" and 'is not a number' error messages are displayed under 'Period End', 'Usage Amount', 'Price' mandatory fields instead of only 'can`t be blank'
- negative values can be selected in 'Period End', 'Usage Amount', 'Price' fields with spin controls

## Summary of change
- refactor model validation to display only one error message when the field is empty
- added validation for maximum values for fields "Usage Amount" of 100 pieces, "Price" of 1000 unit
- limited minimum values for fields when entering values using spin control buttons in the input field


https://github.com/ita-social-projects/ZeroWaste/assets/36037839/4de38d96-6cf6-4674-98af-5151dadeb92e

![only_blank](https://github.com/ita-social-projects/ZeroWaste/assets/36037839/08c51296-c580-433e-9ad6-6f30e232358b)

![max_value_of_100](https://github.com/ita-social-projects/ZeroWaste/assets/36037839/810e1f58-7919-413e-9bc7-7d6ab2fbd49f)


