### PR TITLE
update default state of show_calculators_list (disable)

### DIFF
--- a/config/initializers/flipper/flipper.rb
+++ b/config/initializers/flipper/flipper.rb
@@ -11,7 +11,10 @@ if Flipper::Adapters::ActiveRecord::Feature.table_exists?
   end
 
   Flipper.features.each do |feature|
-    if feature.name == "sandbox_mode" && !DatabaseBackupService.sandbox_enabled?
+    case feature.name
+    when "sandbox_mode"
+      Flipper.disable(feature.name) unless DatabaseBackupService.sandbox_enabled?
+    when "show_calculators_list"
       Flipper.disable(feature.name)
     else
       Flipper.enable(feature.name)


### PR DESCRIPTION
dev
## Zerowaste

* [#836 ]


## Code reviewers

- [x] @obniavko 

### Second Level Review

- [ ] @loqimean 

## Summary of issue

Checkbox 'Show calculators on the public side' should be unselected by default

## Summary of change

Set Checkbox 'Show calculators on the public side' disabled by default

ToDo

## CHECK LIST
- [x]  СI passed
- [ ]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
