### PR TITLE
 Fix  Category Removal on "Edit Product" Page

### DIFF
--- a/app/views/account/products/partials/edit/_form.html.erb
+++ b/app/views/account/products/partials/edit/_form.html.erb
@@ -1,4 +1,4 @@
- <%= simple_form_for product, method: :patch, url: account_product_path, html: { id: dom_id(product, :form) }, data: { controller: "price-form" } do |f| %>
+ <%= simple_form_for product, method: :patch, url: account_product_path, html: { id: dom_id(product, :form) }, data: { controller: "price-form", action: "submit->price-form#submit" } do |f| %>
     <div class="form-group row">
       <div class="my-auto col-12 has-float-label">
         <%= f.input :title, label: t('.title'), class: 'form-control col-sm-11' %>


### PR DESCRIPTION
dev

* resolves #726 


## Code reviewers

- [ ] @loqimean 
- [x] @obniavko 

## Summary of issue

When unchecking the category while editing a product and saving the changes, the categories were not being removed from the product properties on the Products page.

## Summary of change
Previously, the feature aimed at removing categories from products upon unchecking was not functioning as intended. 
To rectify this issue, I incorporated the 'submit' action to ensure seamless functionality with Stimulus for the form. 
This enhancement guarantees that when categories are unchecked and the product is saved, they are effectively removed from the product properties, thereby resolving the reported issue.


https://github.com/ita-social-projects/ZeroWaste/assets/83007830/34fb8a20-b2ae-411f-8845-a28ec83822e5



## Testing approach

### Manually tested the changes by:
Opening the "Edit product" page.
Unchecking the category if present.
Saving the product.
Verifying on the "Products" page that the category is removed as expected.

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
