### PR TITLE
Restyle 'Reset Password' Page.

### DIFF
--- a/app/assets/stylesheets/pages/main.scss
+++ b/app/assets/stylesheets/pages/main.scss
@@ -107,8 +107,8 @@ main p {
       border: none;
 
       &:hover {
-        color: $success;
-        border-color: $success;
+        color: $white;
+        background-color: $matte_lime_green;
       }
 
       &:active {

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -12,7 +12,7 @@
         </div>
 
         <div class="flex justify-center flex-wrap flex-row-reverse pb-4">
-          <%= f.submit t(".send_instructions_button"), class: "btn btn-primary text-center" %>
+          <%= f.submit t(".send_instructions_button"), class: "btn-green text-center px-4 py-2" %>
         </div>
           <div class="text-center text-success before:content-['_\2190']">
           <span class="text-gray text-lg font-medium"><%= t(".back_to") %></span><%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,21 +1,23 @@
 <div class="position-block">
   <div class="card text-center">
     <div class="card-block p-4">
-      <h2><%= t(".forgot_password_header") %></h2>
+      <h1 class="text-center text-2xl text-success py-4"><%= t(".forgot_password_header") %></h1>
+      <p class="pb-4 text-lg"><%= t(".forgot_password_message") %></p>
 
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="flex justify-between flex-wrap mb-4">
-          <%= f.label :email, t(".form.email_label") %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", placeholder: t(".email_placeholder"), required: true  %>
         </div>
 
-        <div class="flex justify-between flex-wrap flex-row-reverse">
-          <%= f.submit t(".send_instructions_button"), class: "btn btn-primary" %>
-
-          <%= render "devise/shared/links" %>
+        <div class="flex justify-center flex-wrap flex-row-reverse pb-4">
+          <%= f.submit t(".send_instructions_button"), class: "btn btn-primary text-center" %>
         </div>
+          <div class="text-center text-success before:content-['_\2190']">
+          <span class="text-gray text-lg font-medium"><%= t(".back_to") %></span><%= render "devise/shared/links" %>
+        </div>
+
       <% end %>
     </div>
   </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,7 +17,7 @@
         <% end %>
 
         <div class="flex flex-row-reverse flex-wrap content-center gap-3">
-          <%= f.submit t(".log_in"), class: "btn w-full font-bold text-center" %>
+          <%= f.submit t(".log_in"), class: "btn w-full font-bold text-center btn-green" %>
 
           <%= render "devise/shared/links" %>
         </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,7 +2,7 @@
   <%= link_to t(".log_in"), new_session_path(resource_name) %>
 <% end %>
 
-<% if devise_mapping.registerable? && controller_name != "registrations" && controller_name != "sessions" %>
+<% if devise_mapping.registerable? && controller_name != "registrations" && controller_name != "sessions" && controller_name != "passwords" %>
   <%= link_to t(".sign_up"), new_registration_path(resource_name) %>
 <% end %>
 
@@ -12,7 +12,7 @@
   </div>
 <% end %>
 
-<% if devise_mapping.omniauthable? %>
+<% if devise_mapping.omniauthable? && controller_name != "passwords"%>
   <div class="block w-full mt-3">
     <fieldset class="auth-login-links">
       <legend class="float-none w-auto text-sm px-2.5 mx-auto"><%= t("devise.omniauth_callbacks.continue_with") %></legend>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -460,7 +460,7 @@ en:
         forgot_password_header: "Forgot your password?"
         forgot_password_message: "Enter your email address and we'll send you reset instructions."
         email_placeholder: "Enter your email"
-        send_instructions_button: "Reset password"
+        send_instructions_button: "Reset"
         back_to: "Back to"
         form:
           email_label: "Email"

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -458,7 +458,10 @@ en:
     passwords:
       new:
         forgot_password_header: "Forgot your password?"
-        send_instructions_button: "Send me reset password instructions"
+        forgot_password_message: "Enter your email address and we'll send you reset instructions."
+        email_placeholder: "Enter your email"
+        send_instructions_button: "Reset password"
+        back_to: "Back to"
         form:
           email_label: "Email"
       edit:

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -476,7 +476,7 @@ uk:
         forgot_password_header: "Забули пароль?"
         forgot_password_message: "Введіть свою електронну адресу, і ми надішлемо вам інструкції для скидання пароля."
         email_placeholder: "Введіть свою ел.пошту"
-        send_instructions_button: "Скинути пароль"
+        send_instructions_button: "Скинути"
         back_to: "Назад до"
         form:
           email_label: "Електронна пошта"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -474,7 +474,10 @@ uk:
     passwords:
       new:
         forgot_password_header: "Забули пароль?"
-        send_instructions_button: "Надішліть мені інструкції щодо скидання пароля"
+        forgot_password_message: "Введіть свою електронну адресу, і ми надішлемо вам інструкції для скидання пароля."
+        email_placeholder: "Введіть свою ел.пошту"
+        send_instructions_button: "Скинути пароль"
+        back_to: "Назад до"
         form:
           email_label: "Електронна пошта"
       edit:

--- a/spec/features/reset_password_spec.rb
+++ b/spec/features/reset_password_spec.rb
@@ -11,8 +11,8 @@ describe "Password Reset Page", js: true do
       receive(:reset_password_instructions)
         .and_return(double(deliver: true))
       visit PASSWORD_RESET_PATH
-      fill_in "Email", with: user.email
-      click_button "Send me reset password instructions"
+      fill_in "user_email", with: user.email
+      click_button "Reset"
       expect(page).to have_content("If your email address exists")
     end
   end
@@ -22,14 +22,6 @@ describe "Password Reset Page", js: true do
       visit PASSWORD_RESET_PATH
       click_on "Log In"
       expect(page).to have_current_path(new_user_session_path)
-    end
-  end
-
-  context "when user clicks Sign up link" do
-    it "redirect to sign up page" do
-      visit PASSWORD_RESET_PATH
-      click_on "Sign Up"
-      expect(page).to have_current_path(new_user_registration_path)
     end
   end
 end


### PR DESCRIPTION
dev
### Resolves:
*  #857 
*  #858 
*  #859  
*  #861 

## Code reviewers

- [ ] @loqimean 
- [x] @DmytroStoliaruk 

## Summary of issue

This pull request aims to enhance the user experience by restyling the "Reset Password" page and removing unnecessary links such as "Log in via Google" and "Sign up." The changes ensure a cleaner and more focused interface for users resetting their passwords.

## Summary of change

- Removed the "Google" link from the "Reset Password" page.
- Removed the "Sign up" link from the "Reset Password" page.
- Applied styling improvements to enhance readability and user interaction on the page.
- Refactor RSpec tests according to changes.
- Added localization translation for English and Ukrainian languages.

![Знімок екрана (633)](https://github.com/ita-social-projects/ZeroWaste/assets/83007830/7f03c911-6578-46f6-b4e4-aee4493be96e)

![Знімок екрана (634)](https://github.com/ita-social-projects/ZeroWaste/assets/83007830/0da6f495-6f30-4fe3-b0a9-e713d90906ec)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
