### PR TITLE
Add title "Diaper calculator"

### DIFF
--- a/app/views/calculators/new_calculator.html.erb
+++ b/app/views/calculators/new_calculator.html.erb
@@ -6,6 +6,7 @@
     </div>
   <% end %>
 
+  <h1 class="text-center text-2xl text-success pt-8 font-semibold"><%= t(".Diaper_сalculator") %></h1>
   <div class="flex-wrap d-flex justify-content-around calculator_wrap ms-5">
     <%= simple_form_for(:child, url: "#", html: { class: "simple_form_calculator",
                                             data: { controller: "input-child-info",

--- a/app/views/calculators/new_calculator.html.erb
+++ b/app/views/calculators/new_calculator.html.erb
@@ -6,7 +6,7 @@
     </div>
   <% end %>
 
-  <h1 class="text-center text-2xl text-success pt-8 font-semibold"><%= t(".Diaper_сalculator") %></h1>
+  <h1 class="text-center text-2xl text-success pt-8 font-semibold"><%= t(".diaper_сalculator") %></h1>
   <div class="flex-wrap d-flex justify-content-around calculator_wrap ms-5">
     <%= simple_form_for(:child, url: "#", html: { class: "simple_form_calculator",
                                             data: { controller: "input-child-info",

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -47,6 +47,7 @@ en:
     index:
       meta-title: "Calculators"
     new_calculator:
+      diaper_сalculator: "Diaper calculator"
       form:
         description: "Child’s age:"
         price: "Price category"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -14,7 +14,7 @@ uk:
       truncate: "&hellip;"
   calculators:
     new_calculator:
-      Diaper_сalculator: "Калькулятор підгузків"
+      diaper_сalculator: "Калькулятор підгузків"
       form:
         description: "Вік дитини:"
         price: "Цінова категорія"
@@ -23,10 +23,18 @@ uk:
         budgetary: "бюджетна"
         medium: "середня"
         premium: "преміум"
-      bought_diapers: "ви вже використали"
-      money_spent: "ви вже витратили"
-      will_buy_diapers: "ви ще використаєте"
-      money_will_be_spent: "ви ще витратите"
+      bought_diapers:
+        one: "підгузок ви вже використали"
+        few: "підгузки ви вже використали"
+        many: "підгузків ви вже використали"
+        other: "підгузків ви вже використали"
+      money_spent: "грн ви вже витратили"
+      will_buy_diapers:
+        one: "підгузок ви ще використаєте"
+        few: "підгузки ви ще використаєте"
+        many: "підгузків ви ще використаєте"
+        other: "підгузків ви ще використаєте"
+      money_will_be_spent: "грн ви ще витратите"
       pieces: "шт."
       unit: "грн"
     old_calculator:

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -14,6 +14,7 @@ uk:
       truncate: "&hellip;"
   calculators:
     new_calculator:
+      Diaper_сalculator: "Калькулятор підгузків"
       form:
         description: "Вік дитини:"
         price: "Цінова категорія"
@@ -22,18 +23,10 @@ uk:
         budgetary: "бюджетна"
         medium: "середня"
         premium: "преміум"
-      bought_diapers:
-        one: "підгузок ви вже використали"
-        few: "підгузки ви вже використали"
-        many: "підгузків ви вже використали"
-        other: "підгузків ви вже використали"
-      money_spent: "грн ви вже витратили"
-      will_buy_diapers:
-        one: "підгузок ви ще використаєте"
-        few: "підгузки ви ще використаєте"
-        many: "підгузків ви ще використаєте"
-        other: "підгузків ви ще використаєте"
-      money_will_be_spent: "грн ви ще витратите"
+      bought_diapers: "ви вже використали"
+      money_spent: "ви вже витратили"
+      will_buy_diapers: "ви ще використаєте"
+      money_will_be_spent: "ви ще витратите"
       pieces: "шт."
       unit: "грн"
     old_calculator:


### PR DESCRIPTION
dev
* [Project ticket #863](https://github.com/ita-social-projects/ZeroWaste/issues/863)

## Code reviewers

- [ ] @loqimean 
- [x] @dafeys 

## Summary of issue

Calculator title is absent on page.

## Summary of change
'Diaper сalculator/Калькулятор підгузків' Calculator title added in the first section. 
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/95bb1054-165e-4bda-b18a-4b0a318bea75)
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/08e02f9e-aadb-4e84-b24f-a23821a3df09)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
