### PR TITLE
Improve the drop-down menu in new calculator design

### DIFF
--- a/app/assets/stylesheets/pages/calculator.scss
+++ b/app/assets/stylesheets/pages/calculator.scss
@@ -74,7 +74,7 @@
   }
 
   .form_fild {
-    min-height: 33px;
+    min-height: 40px;
     font-weight: 400;
     margin-bottom: 24px;
     max-width: 275px;
@@ -83,17 +83,23 @@
 
   .age_wrapper {
     align-items: center;
+
     .select-age {
+      appearance: none;
       background-color: $light_gray;
       background-image: none;
-      width: 10%;
-      margin-left: 40px;
-      text-align: center;
       border: none;
-      outline: none;
       color: $dark_gray;
-      appearance: none;
-      padding: 0rem;
+      width: 70px;
+      margin: 0 5px 0 25px;
+      padding: 1px 0 1px 15px;
+      text-align: left;
+    }
+
+    .select-age-label {
+      margin-left: -40px;
+      pointer-events: none;
+      z-index: 1;
     }
   }
 

--- a/app/views/calculators/new_calculator.html.erb
+++ b/app/views/calculators/new_calculator.html.erb
@@ -14,7 +14,7 @@
                                                     input_child_info_results_outlet: ".result" }}) do |form| %>
       <div class="flex-item flex-column">
         <div class="pb-2 input_lable">
-          <%= t(".form.description") %>
+          <%= label_tag "child_years", t(".form.description") %>
         </div>
 
         <div class="flex-row rounded flex-item w-100 age_wrapper form_fild">
@@ -24,27 +24,27 @@
                                 class: "select-age ms-2 rounded",
                                 data: { input_child_info_target: "year", action: "input-child-info#yearChanged" } %>
 
-          <%= t(".form.childs_years_label") %>
+          <%= label_tag "child_years", t(".form.childs_years_label"), class: "select-age-label" %>
 
           <%= form.input_field :months,
-                              collection: month_number("new"),
-                              prompt: "__",
-                              class: "select-age rounded",
-                              data: { input_child_info_target: "month" } %>
+                                collection: month_number("new"),
+                                prompt: "__",
+                                class: "select-age rounded",
+                                data: { input_child_info_target: "month" } %>
 
-          <%= t(".form.childs_months_label") %>
+          <%= label_tag "child_months", t(".form.childs_months_label"), class: "select-age-label" %>
         </div>
 
         <div class="pb-2 input_lable">
-          <%= t(".form.price") %>
+          <%= label_tag "child_product_category", t(".form.price") %>
         </div>
 
         <%= form.input_field :product_category,
-                            collection: @diaper_categories,
-                            selected: @preferable_category&.id,
-                            label: t(".form_price"),
-                            class: "form_fild price_select rounded w-100",
-                            data: { input_child_info_target: "productCategory" } %>
+                             collection: @diaper_categories,
+                             selected: @preferable_category&.id,
+                             label: t(".form_price"),
+                             class: "form_fild price_select rounded w-100",
+                             data: { input_child_info_target: "productCategory" } %>
 
         <%= form.submit t("calculators.buttons.calculate"),
                     class: "calculate-btn result-btn",


### PR DESCRIPTION
dev

- #868

## Code reviewers
- [ ] @iambrozjak 
- [ ] @loqimean 

## Summary of issue
- The drop-down menu for age is narrow in new calculator design, and it is difficult to point to it item
- There is no focus when clicking on "Цінова категорія" or "Вік дитини"

## Summary of change
- Changed the style for the drop-down menu
- Set the same height for the fields "Цінова категорія" and "Вік дитини"
- Added label_tag for the corresponding dropdowns

![image](https://github.com/ita-social-projects/ZeroWaste/assets/36037839/5cbf7963-e410-47d0-b5cf-b057693e3cf7)

https://github.com/ita-social-projects/ZeroWaste/assets/36037839/2393b5b2-3deb-42a0-97bf-7bf3296ff06c
