### PR TITLE
Hide 'devise/shared/links' partial in login page HTML

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,7 +19,7 @@
         <div class="flex flex-row-reverse flex-wrap content-center gap-3">
           <%= f.submit t(".log_in"), class: "btn w-full font-bold text-center btn-green" %>
 
-          <%= render "devise/shared/links" %>
+          <%#= render "devise/shared/links" %>
         </div>
       <% end %>
     </div>

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -4,13 +4,13 @@
 })%>
 
 <section class="jumbotron main-container rounded mt-16">
-  <h2 class="text-center text-2xl text-success my-8 "><%= t('about_us.title') %></h2>
+  <h2 class="text-center text-2xl text-success my-8 font-semibold"><%= t('about_us.title') %></h2>
   <p class="text-center text-xl text-black"><%= t('about_us.description.first_paragraph') %></p>
   <p class="text-center text-xl text-black"><%= t('about_us.description.second_paragraph') %></p>
   <p class="text-center text-xl text-black mb-8"><%= t('about_us.description.third_paragraph') %></p>
 </section>
 <section class="jumbotron main-container rounded mt-16">
-  <h2 class="text-center text-2xl text-success my-8"><%= t('our_team.title') %></h2>
+  <h2 class="text-center text-2xl text-success my-8 font-semibold"><%= t('our_team.title') %></h2>
   <p class="text-center text-xl text-black"><%= t('our_team.description') %></p>
   <div class="flex justify-between items-center mt-24">
     <%= link_to image_tag("logo_zerowaste.png", alt: "Zero Waste Logo", class: "logo-zerowaste"), "https://zerowastelviv.org.ua/", target: "_blank", rel: "noopener" %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -3,7 +3,7 @@
 <div class="position-block">
   <div class="card">
     <div class="card-block p-4">
-      <h2 class="text-center text-2xl text-success py-4">
+      <h2 class="text-center text-2xl text-success py-4 font-semibold">
         <%= t('.contact_us_header') %>
       </h2>
       <div class="contact-form">


### PR DESCRIPTION
dev
* resolves #837 

## Code reviewers

- [ ] @loqimean 
- [x] @obniavko 

## Summary of issue

Extra container "Or continue with" is on LogIn Page.
Must be hidden.

#### LogIn Page (Before)
![Image](https://github.com/ita-social-projects/ZeroWaste/assets/152202895/dfb63da3-5d44-4c82-a466-8368c0cbf646)

## Summary of change

The 'devise/shared/links' partial in the login page HTML has been hidden (commented).

#### LogIn Page (After)
![LogIn Page](https://github.com/ita-social-projects/ZeroWaste/assets/83007830/0e9ceafa-3662-4df7-8405-24be094925cf)


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
