### PR TITLE
[Products] [Add product] Resolve Validation Errors for Sum Field.

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -42,7 +42,7 @@ class Product < ApplicationRecord
   end
 
   def find_or_build_price_for_category(category)
-    prices.find_by(category: category) || prices.build(category: category)
+    prices.find { |p| p.category_id == category.id } || prices.build(category: category)
   end
 
   def build_unsigned_categories

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,3 +1,3 @@
-<% flash.each do |message_type, message| %>
+<% flash.to_h.except("timedout").each do |message_type, message| %>
   <%= turbo_stream.toast(message, background: message_type) %>
 <% end %>


### PR DESCRIPTION
dev
* resolves  #724 
* resolves #804 
## Code reviewers

- [x] @dafeys 
- [x] @loqimean 

## Summary of issue
When entering an excessively long value in the category field (e.g., 999999999999999999999999999999999999999999999999) or a negative value in the 'Sum' field (e.g., -23) and submitting the form, an error message does not appear.



## Summary of change
The validation and error handling have been updated to display specific error messages ('Sum is too long' or 'Sum must be greater than or equal to 0') beneath the category sum field, as intended.

![errors](https://github.com/ita-social-projects/ZeroWaste/assets/83007830/ea95fedc-3a1d-4903-9bf5-747383f407b7)

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
