### PR TITLE
884 header width as main container

### DIFF
--- a/app/assets/stylesheets/components/header.css
+++ b/app/assets/stylesheets/components/header.css
@@ -1,6 +1,7 @@
 @layer components {
   .page-header {
-    @apply w-full xl:max-w-fit mx-auto mb-4 flex border-b-2 border-gray justify-center;
+    @apply w-full mb-4 flex mx-auto border-b-2 border-gray;
+    max-width: $max_width_content;
   }
 
   .tab {

--- a/app/views/account/shared/_navigation.html.erb
+++ b/app/views/account/shared/_navigation.html.erb
@@ -1,9 +1,8 @@
-
 <header class="page-header">
   <div data-controller="burger" class="flex justify-between w-full">
     <%= link_to image_tag("logo_zerowaste.png", alt: "Zero Waste Logo"), root_path, class: "logo-zerowaste" %>
-    <div data-burger-target="navbarNav" class="hidden xl:flex">
-      <ul class="admin-menu-list">
+    <div data-burger-target="navbarNav" class="hidden xl:flex flex-1">
+      <ul class="admin-menu-list items-start xl:items-center">
         <li>
           <% if Flipper[:show_calculators_list].enabled? %>
             <%= link_to t(".calculators"), calculators_path, class: "tab-main-page" %>
@@ -34,17 +33,12 @@
             <%= link_to t("layouts.navigation.log_in"), new_user_session_path, class: "tab-main-page", id: "log_in" %>
           </li>
         <% end %>
-        <li>
-          <div class="flex items-center">
-            <%= link_to t(".donate"), "https://zerowastelviv.org.ua/pidtrymaty/", target: "_blank", rel: "noopener", class: "header-btns main-btn btn-outline-green" %>
-          </div>
-        </li>
-        <li>
-          <div class="flex items-center">
-            <%= link_to t("#{switch_locale_to}"), url_for(locale: switch_locale_to), class: "header-btns main-btn btn-outline-gray" %>    
-          </div>
-       </li>
       </ul>
+            
+      <div class="admin-menu-list">
+        <%= link_to t(".donate"), "https://zerowastelviv.org.ua/pidtrymaty/", target: "_blank", rel: "noopener", class: "header-btns main-btn btn-outline-green" %>
+        <%= link_to t("#{switch_locale_to}"), url_for(locale: switch_locale_to), class: "header-btns main-btn btn-outline-gray" %>    
+      </div> 
     </div>
     <div class="flex ml-auto">
       <div class="mt-6 ml-2">

--- a/app/views/account/shared/_navigation.html.erb
+++ b/app/views/account/shared/_navigation.html.erb
@@ -41,7 +41,7 @@
       </div> 
     </div>
     <div class="flex ml-auto">
-      <div class="mt-6 ml-2">
+      <div class="mt-6">
         <button data-action="click->burger#toggle" class="admin-menu-burger-button">
           <%= image_tag "icons/burger-menu-lines.svg", class: "block h-8 w-8", "data-burger-target": "iconLines" %>
           <%= image_tag "icons/burger-menu-cross.svg", class: "block h-8 w-8 hidden", "data-burger-target": "iconCross" %>


### PR DESCRIPTION
dev
## Zerowaste

* [#884 ]


## Code reviewers

- [x] @Natali-Kotelnitska 

### Second Level Review

- [ ] @loqimean 
## Summary of issue



## Summary of change

1. Change the container size for the main menu (it should be the same size as on other pages)
2. Update main menu styles

Result:


https://github.com/ita-social-projects/ZeroWaste/assets/35365419/9e0b3e19-b034-4b22-8eae-40f3149c16f2



<img width="1626" alt="Screenshot 2024-06-06 at 22 10 52" src="https://github.com/ita-social-projects/ZeroWaste/assets/35365419/f8507241-8eb0-45e5-b135-92a7241c690f">


<img width="983" alt="Screenshot 2024-06-06 at 20 56 17" src="https://github.com/ita-social-projects/ZeroWaste/assets/35365419/76e3d8c7-7a59-4862-bc3b-3e5969850b04">



## CHECK LIST
- [x]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
