### PR TITLE
Changed view button "To main".

### DIFF
--- a/app/views/calculators/new_calculator.html.erb
+++ b/app/views/calculators/new_calculator.html.erb
@@ -1,12 +1,12 @@
 <div class="rounded jumbotron jumbotron-fluid position-relative">
   <%= link_to root_path, class: "px-2 mt-3 rounded back-link" do %>
-    <div class="back-text">
-      <%= inline_svg("icons/arrow-left.svg", class: "z-1") %>
-      <%= t("calculators.buttons.to_main") %>
+    <div class="flex items-center gap-1 mt-2 ml-2 w-[160px]">
+      <%= inline_svg("icons/arrow-left.svg", class: "z-1 h-5") %>
+      <span class="text-success text-lg"><%= t("calculators.buttons.to_main")%></span>
     </div>
   <% end %>
 
-  <h1 class="text-center text-2xl text-success pt-8 font-semibold"><%= t(".diaper_сalculator") %></h1>
+  <h1 class="text-center text-2xl text-success font-semibold pt-12"><%= t(".diaper_сalculator") %></h1>
   <div class="flex-wrap d-flex justify-content-around calculator_wrap ms-5">
     <%= simple_form_for(:child, url: "#", html: { class: "simple_form_calculator",
                                             data: { controller: "input-child-info",

--- a/app/views/calculators/new_calculator.html.erb
+++ b/app/views/calculators/new_calculator.html.erb
@@ -1,12 +1,10 @@
 <div class="rounded jumbotron jumbotron-fluid position-relative">
-  <%= link_to root_path, class: "px-2 mt-3 rounded back-link" do %>
-    <div class="flex items-center gap-1 mt-2 ml-2 w-[160px]">
-      <%= inline_svg("icons/arrow-left.svg", class: "z-1 h-5") %>
-      <span class="text-success text-lg"><%= t("calculators.buttons.to_main")%></span>
-    </div>
+  <%= link_to root_path, class: "p-3 inline-flex items-center gap-2" do %>
+    <%= inline_svg("icons/arrow-left.svg", class: "z-1 h-4") %>
+    <span class="text-lg text-success"><%= t("calculators.buttons.to_main")%></span>
   <% end %>
 
-  <h1 class="text-center text-2xl text-success font-semibold pt-12"><%= t(".diaper_сalculator") %></h1>
+  <h1 class="text-2xl font-semibold text-center text-success"><%= t(".diaper_сalculator") %></h1>
   <div class="flex-wrap d-flex justify-content-around calculator_wrap ms-5">
     <%= simple_form_for(:child, url: "#", html: { class: "simple_form_calculator",
                                             data: { controller: "input-child-info",


### PR DESCRIPTION
* [Project ticket #886](https://github.com/ita-social-projects/ZeroWaste/issues/886)

## Code reviewers

- [ ] @loqimean  
- [x] @dafeys

## Summary of issue
The “To main” button should be larger. The arrow and text should be centered.

## Summary of change
Changed view button "To main" using tailwind.css.  The arrow and text are centered. The button size has been increased. Text color changed and indents added.
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/711ae93f-0935-45d6-8186-c873a48b23cf)
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/a6c636d3-ba06-40da-bae0-dd498a678852)
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/69bbfd2e-ab8d-4963-bef2-ff20d38098ad)
![image](https://github.com/ita-social-projects/ZeroWaste/assets/129009813/58218e36-b926-4afe-97b6-21f7c9e9f48c)


## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
