### PR TITLE
Restrict input to two decimal places in price input fields

### DIFF
--- a/app/javascript/controllers/price_form_controller.js
+++ b/app/javascript/controllers/price_form_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
 
     this.priceInputTargets.forEach(input => {
       input.addEventListener('input', this.validatePriceInput.bind(this));
+      input.addEventListener('keydown', this.restrictDecimalInput.bind(this));
     });
   }
 
@@ -55,6 +56,15 @@ export default class extends Controller {
     } else {
       errorMessage.style.display = "none";
       target.style.borderColor = "";
+    }
+  }
+
+  restrictDecimalInput(event) {
+    const target = event.target;
+    const inputValue = target.value;
+    
+    if (inputValue.includes('.') && inputValue.split('.')[1].length >= 2 && !["Backspace", "Delete"].includes(event.key)) {
+      event.preventDefault();
     }
   }
 }


### PR DESCRIPTION
#### Resolves:  #817 

## Code reviewers

- [ ] @loqimean 

## Summary of issue

The current implementation of the price input fields allows users to enter an unlimited number of decimal places. 

## Summary of change

Added a restrictDecimalInput in price_form_controller.js. It won't allow a user to enter more than two decimal places in the price input fields. This method is designed to intercept key down events and prevent further input if the decimal part of the number already has two digits.
## Testing approach


## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
