### PR TITLE
790 ransack clear filters

### DIFF
--- a/app/views/account/shared/_search_form.html.erb
+++ b/app/views/account/shared/_search_form.html.erb
@@ -2,5 +2,6 @@
   <%= search_form_for(q, url: search_url, method: :get, class: "d-flex mb-5") do |f| %>
     <%= f.search_field search_attribute, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
     <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
+    <%= link_to t(".clear_button"), search_url, class:"btn btn-grey px-4 items-center ml-2" %>
   <% end %>
 </div>

--- a/app/views/account/shared/_search_form.html.erb
+++ b/app/views/account/shared/_search_form.html.erb
@@ -2,6 +2,6 @@
   <%= search_form_for(q, url: search_url, method: :get, class: "d-flex mb-5") do |f| %>
     <%= f.search_field search_attribute, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
     <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
-    <%= link_to t(".clear_button"), search_url, class:"btn btn-grey px-4 items-center ml-2" %>
+    <%= link_to t(".clear_button"), search_url, class: "btn btn-grey px-4 items-center ml-2" %>
   <% end %>
 </div>

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -14,3 +14,4 @@ en:
       search_form:
         search_placeholder: "Search"
         search_button: "Search"
+        clear_button: "Clear"

--- a/config/locales/uk/layouts.yml
+++ b/config/locales/uk/layouts.yml
@@ -14,3 +14,4 @@ uk:
       search_form:
         search_placeholder: "Пошук"
         search_button: "Шукати"
+        clear_button: "Очистити"


### PR DESCRIPTION
Resolves: https://github.com/ita-social-projects/ZeroWaste/issues/790


## Code reviewers

- [ ] @loqimean 

## Summary of issue

There is no logic to clear filters in account/calculators, categories, products etc. pages.

## Summary of change

Added button to ransack form that links user to clear (without any filters) page.
![image](https://github.com/user-attachments/assets/4d89c2f1-aa47-469d-8ff8-8cba2e92f75b)


## CHECK LIST
- [x]  СI passed
- [ ]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
