### PR TITLE
Fix migration error

### DIFF
--- a/db/migrate/20250123134935_create_authorization.rb
+++ b/db/migrate/20250123134935_create_authorization.rb
@@ -1,0 +1,11 @@
+class CreateAuthorization < ActiveRecord::Migration[7.2]
+  def change
+    create_table :authorizations do |t|
+      t.string :uid
+      t.string :provider
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20250123135823_add_index_to_authorizations_on_uid_and_provider.rb
+++ b/db/migrate/20250123135823_add_index_to_authorizations_on_uid_and_provider.rb
@@ -1,4 +1,4 @@
-class AddIndexToAuthorizationsOnUidAndProvider < ActiveRecord::Migration[7.1]
+class AddIndexToAuthorizationsOnUidAndProvider < ActiveRecord::Migration[7.2]
   def change
     add_index :authorizations, [:uid, :provider], unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_14_131028) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_23_135823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_14_131028) do
     t.text "metadata"
     t.string "service_name", null: false
     t.bigint "byte_size", null: false
-    t.string "checksum"
+    t.string "checksum", null: false
     t.datetime "created_at", precision: nil, null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -59,7 +59,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_14_131028) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug"
-    t.boolean "preferable", default: false
+    t.boolean "preferable", default: false, null: false
     t.index ["name"], name: "index_calculators_on_name", unique: true
     t.index ["slug"], name: "index_calculators_on_slug", unique: true
     t.index ["uuid"], name: "index_calculators_on_uuid", unique: true
@@ -211,9 +211,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_14_131028) do
     t.string "last_sign_in_ip"
     t.string "provider"
     t.string "uid"
-    t.boolean "blocked", default: false
+    t.boolean "blocked", default: false, null: false
     t.integer "role", default: 0
-    t.boolean "receive_recomendations", default: false
+    t.boolean "receive_recomendations", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## Code reviewers

- [x] @loqimean 
- [ ] @DanielVajnagi 


## Summary of issue

Getting error when migrate AddIndexToAuthorizationsOnUidAndProvider migration
```
== 20241114131028 AddIndexToAuthorizationsOnUidAndProvider: migrating =========
-- add_index(:authorizations, [:uid, :provider], {:unique=>true})
bin/rails aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

PG::UndefinedTable: ERROR:  relation "authorizations" does not exist
/home/olexander/workspace/ZeroWaste/db/migrate/20241114131028_add_index_to_authorizations_on_uid_and_provider.rb:3:in `change'

Caused by:
ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "authorizations" does not exist (ActiveRecord::StatementInvalid)
/home/olexander/workspace/ZeroWaste/db/migrate/20241114131028_add_index_to_authorizations_on_uid_and_provider.rb:3:in `change'

Caused by:
PG::UndefinedTable: ERROR:  relation "authorizations" does not exist (PG::UndefinedTable)
/home/olexander/workspace/ZeroWaste/db/migrate/20241114131028_add_index_to_authorizations_on_uid_and_provider.rb:3:in `change'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

## Summary of change

Added migration of creating authorization table


## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
