### PR TITLE
Update bigdecimal gem in Gemfile and Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "net-smtp"
 
 gem "country_select"
 
-gem "bigdecimal", "3.0.2"
+gem "bigdecimal", "3.1.9"
 gem "rails-i18n", "~> 7.0.0"
 
 # Use Active Storage variant

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,8 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
-    bigdecimal (3.0.2)
+    bcrypt_pbkdf (1.1.1-arm64-darwin)
+    bigdecimal (3.1.9)
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -199,6 +200,7 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
     flipper (1.3.1)
       concurrent-ruby (< 2)
@@ -301,6 +303,8 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -543,6 +547,8 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
+    tailwindcss-rails (2.7.9-arm64-darwin)
+      railties (>= 7.0.0)
     tailwindcss-rails (2.7.9-x86_64-linux)
       railties (>= 7.0.0)
     temple (0.10.3)
@@ -584,6 +590,7 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -594,7 +601,7 @@ DEPENDENCIES
   any_login
   babosa
   bcrypt_pbkdf
-  bigdecimal (= 3.0.2)
+  bigdecimal (= 3.1.9)
   bootsnap
   bootstrap
   breadcrumbs_on_rails


### PR DESCRIPTION
## Code reviewers

- [ ] @loqimean 

## Summary of issue

The project didn`t deploy locally due to incompatibility between the version of bigdecimal gem 3.0.2 and the ruby ​​version 3.3.5.

## Summary of change

Updated the version of bigdecimal gem to 3.1.9.

## CHECK LIST
- [x]  I have updated the version of bigdecimal gem in Gemfile and Gemfile.lock