### PR TITLE
Added underline to the left link in the footer

### DIFF
--- a/app/views/shared/_account_footer.html.erb
+++ b/app/views/shared/_account_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="account-footer">
   <div class="container mx-auto">
     <div class="account-footer_text">
-      <p>&copy; <%= Date.current.year %> <span class="text-success font-bold">Zero Waste Lviv</span></p>
+      <p>&copy; <%= Date.current.year %> <%= link_to "Zero Waste Lviv", t('link.zerowaste_link'), target: "_blank", class: "text-success underline" %></p>
       <p><%= t(".created_with") %> <span class="text-red-500">&hearts;</span> <%= t(".by") %> <%= link_to "SoftServe Academy", t('link.softserve_ita_link'), target: "_blank", class: "text-success underline" %></p>
     </div>
   </div>


### PR DESCRIPTION
## Checklist

- [x] I have added underline to the left link in the footer

## Changes

### What is the current behavior?

The link isn't underlined on the left and underlined on the right
<img width="1467" alt="Знімок екрана 2025-05-18 о 22 38 49" src="https://github.com/user-attachments/assets/3413f93c-df9b-4ef8-83a6-bc33cac27fc9" />

### What is the expected behavior?

Links in the footer are unified, showed with underline
<img width="1436" alt="Знімок екрана 2025-05-18 о 22 39 50" src="https://github.com/user-attachments/assets/1cad2cba-f1c5-4be3-b2ab-4e19de5f186b" />

