### PR TITLE
improved showpage + color input field with bootstrap

### DIFF
--- a/app/assets/stylesheets/components/form.css
+++ b/app/assets/stylesheets/components/form.css
@@ -39,8 +39,10 @@
 
   /* Input styles */
   .color-input {
-    @apply p-2 w-28 h-14;
+    width: 8rem !important;
+    height: 3.5rem;
   }
+
   /* Formula field */
   .formula{
     border-radius: inherit !important;

--- a/app/views/account/calculators/show.html.erb
+++ b/app/views/account/calculators/show.html.erb
@@ -6,15 +6,32 @@
 
   <div class="calc-details mb-4">
     <span class="text-lg showpage-text"><%= t('.name') %>:</span>
-    <p class="text-2xl font-extrabold"> <%= @calculator.name %> </p>
+    <p class="text-2xl font-extrabold"><%= @calculator.name %></p>
   </div>
 
   <div class="calc-details mb-4">
     <span class="text-lg showpage-text"><%= t('.slug') %>:</span>
-    <p class="font-bold"> <%= @calculator.slug %> </p>
+    <p class="font-bold"><%= @calculator.slug %></p>
   </div>
 
-  <!-- Display Fields -->
+  <!-- Color -->
+  <div class="calc-details mb-4">
+    <span class="text-lg showpage-text"><%= t('.color') %>:</span>
+    <div class="flex items-center gap-2 mt-1">
+      <div class="w-6 h-6 rounded border" style="background-color: <%= @calculator.color %>;"></div>
+      <span><%= @calculator.color %></span>
+    </div>
+  </div>
+
+  <!-- Notes -->
+  <% if @calculator.notes.present? %>
+    <div class="calc-details mb-4">
+      <h3 class="text-lg showpage-text"><%= t('.notes') %>:</h3>
+      <p><%= sanitize_content(@calculator.notes) %></p>
+    </div>
+  <% end %>
+
+  <!-- Fields -->
   <div class="calc-details mb-4">
     <h3 class="text-lg showpage-text"><%= t('.fields') %>:</h3>
     <% @calculator.fields.each do |field| %>
@@ -27,7 +44,7 @@
     <% end %>
   </div>
 
-  <!-- Display Formulas -->
+  <!-- Formulas -->
   <div class="calc-details mb-4">
     <h3 class="text-lg showpage-text"><%= t('.formulas') %>:</h3>
     <% @calculator.formulas.each do |formula| %>
@@ -44,7 +61,7 @@
 
   <%= render "calculators/partials/logo_picture", calculator: @calculator %>
 
-  <div class="showpage-buttons">
+  <div class="showpage-buttons flex flex-wrap gap-2">
     <%= link_to t('.edit'),
                 edit_account_calculator_path(@calculator.slug, locale: I18n.locale),
                 class: "btn btn-green" %>
@@ -55,5 +72,10 @@
                   class: "btn btn-danger" do %>
       <%= t('.delete') %>
     <% end %>
+
+    <%= link_to t('.view_public'),
+                public_calculator_path(@calculator.slug, locale: I18n.locale),
+                class: "btn btn-blue",
+                target: "_blank" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,6 @@ Rails.application.routes.draw do
     post "/receive_recomendations", to: "calculators#receive_recomendations"
     get "/calculators/:slug", to: "calculators#show", as: :public_calculator
 
-
     get "about-us", to: "home#about", as: "about"
 
     resources :calculators, only: [:index, :show], param: :slug do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
     get "/calculator", to: "calculators#calculator"
     get "/mhc_calculator", to: "calculators#mhc_calculator"
     post "/receive_recomendations", to: "calculators#receive_recomendations"
+    get "/calculators/:slug", to: "calculators#show", as: :public_calculator
+
 
     get "about-us", to: "home#about", as: "about"
 


### PR DESCRIPTION
## Checklist

- [ ] I have added tests to cover my ruby code changes
- [ ] I have added screenshots to show the changes on the UI
- [ ] I have added a description of the changes to the PR description

## What was done aside from the main task as a part of this PR?

Replaced the Tailwind-styled color input on the creation page with a Bootstrap-styled color input

## Changes

### What is the current behavior?

The admin show page uses TailwindCSS for styling, but Tailwind is currently disabled on the admin side, resulting in broken or missing styles.

### What is the expected behavior?

The admin show page should now use Bootstrap for styling instead of TailwindCSS.

The appearance of the admin show page should now match the attached screenshot, with TailwindCSS still disabled on the admin side.

![image_2025-05-29_17-03-19](https://github.com/user-attachments/assets/36ee1da5-b2c6-4b61-b44b-f71e87775bca)

