### PR TITLE
1051 Hide mhc calculator info with condition

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,18 +1,19 @@
 <main class="container">
   <h1 class="homepage_title"><%= t '.homepage_title' %></h1>
 
-  <div class="flex flex-col md:flex-row gap-6">
+  <div class="flex flex-col md:flex-row items-center justify-center gap-6">
     <div class="w-full md:w-1/2">
       <h2 class="homepage_title"><%= t '.diaper_calculator_title' %></h2>
       <p><%= t '.diaper_calculator_description' %></p>
       <%= link_to t('.calculate'), calculator_path, class: "main-btn btn-outline-green" %>
     </div>
-
-    <div class="w-full md:w-1/2">
-      <h2 class="homepage_title"><%= t '.mhc_calculator_title' %></h2>
-      <p><%= t '.mhc_calculator_description' %></p>
-      <%= link_to t('.calculate'), mhc_calculator_path, class: "main-btn btn-outline-green" %>
-    </div>
+    <% if Flipper[:mhc_calculator_status].enabled? %>
+      <div class="w-full md:w-1/2">
+        <h2 class="homepage_title"><%= t '.mhc_calculator_title' %></h2>
+        <p><%= t '.mhc_calculator_description' %></p>
+        <%= link_to t('.calculate'), mhc_calculator_path, class: "main-btn btn-outline-green" %>
+      </div>
+    <% end %>
   </div>
 
   <%= link_to_external(text: t('.visit_website'), url: t(".link"), class: 'main-btn btn-outline-gray justify-center btn-space mt-6') %>


### PR DESCRIPTION
## Checklist

- [ ] I have added tests to cover my ruby code changes
- [x] I have added screenshots to show the changes on the UI
- [x] I have added a description of the changes to the PR description

## What was done aside from the main task as a part of this PR?

- Nothing

## Changes

- Added condition to show mhc calculator info in root page

### What is the current behavior?

#### Admin enabled mhc
![image](https://github.com/user-attachments/assets/eb27611c-416b-41a5-8b27-bb56422c0044)
#### Admin disabled mhc
![image](https://github.com/user-attachments/assets/eb27611c-416b-41a5-8b27-bb56422c0044)

### What is the expected behavior?

#### Admin enabled mhc
![image](https://github.com/user-attachments/assets/eb27611c-416b-41a5-8b27-bb56422c0044)
#### Admin disabled mhc
![image](https://github.com/user-attachments/assets/85e88d33-5669-4fa7-a9a5-72a42e6eeba9)
