### PR TITLE
1062 Show original calculator reference after duplication

### DIFF
--- a/app/controllers/account/calculators_controller.rb
+++ b/app/controllers/account/calculators_controller.rb
@@ -47,6 +47,7 @@ class Account::CalculatorsController < Account::BaseController
 
   def duplicate
     @calculator = resource.amoeba_dup
+    @calculator.original_calculator = resource
 
     render :new
   end

--- a/app/controllers/account/calculators_controller.rb
+++ b/app/controllers/account/calculators_controller.rb
@@ -15,10 +15,17 @@ class Account::CalculatorsController < Account::BaseController
   end
 
   def new
-    @calculator = Calculator.new
+    if params[:original_calculator_id].present?
+      original_calculator = Calculator.find(params[:original_calculator_id])
 
-    @calculator.fields.build
-    @calculator.formulas.build
+      @calculator                     = original_calculator.amoeba_dup
+      @calculator.original_calculator = original_calculator
+    else
+      @calculator = Calculator.new
+
+      @calculator.fields.build
+      @calculator.formulas.build
+    end
   end
 
   def edit
@@ -45,13 +52,6 @@ class Account::CalculatorsController < Account::BaseController
     end
   end
 
-  def duplicate
-    @calculator = resource.amoeba_dup
-    @calculator.original_calculator = resource
-
-    render :new
-  end
-
   def destroy
     @calculator = resource
 
@@ -72,7 +72,7 @@ class Account::CalculatorsController < Account::BaseController
 
   def calculator_params
     params.require(:calculator).permit(
-      :id, :en_name, :uk_name, :color, :logo_picture, :uk_notes, :en_notes,
+      :id, :en_name, :uk_name, :color, :logo_picture, :uk_notes, :en_notes, :original_calculator_id,
       formulas_attributes: [:id, :expression, :en_label, :uk_label, :calculator_id, :en_unit, :uk_unit, :priority, :formula_image, :relation, :_destroy],
       fields_attributes: [:id, :en_label, :uk_label, :var_name, :kind, :value, :_destroy,
         categories_attributes: [:id, :en_name, :uk_name, :price, :_destroy]]

--- a/app/models/calculator.rb
+++ b/app/models/calculator.rb
@@ -28,6 +28,9 @@ class Calculator < ApplicationRecord
   attribute :logo_placeholder, :string, default: "https://via.placeholder.com/428x307?text=Logo"
   translates :name, :notes
 
+  belongs_to :original_calculator, class_name: "Calculator", optional: true, inverse_of: :duplicate_calculators
+  has_many :duplicate_calculators, class_name: "Calculator", foreign_key: :original_calculator_id, dependent: :nullify, inverse_of: :original_calculator
+
   has_one_attached :logo_picture
   has_many :fields, dependent: :destroy
   has_many :formulas, -> { ordered_by_priority }, dependent: :destroy, inverse_of: :calculator

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -46,7 +46,8 @@
                                data: { action: "dialog#close" },
                                class: "btn btn-outline-green px-4 py-2 me-3" %>
                 <%= button_to t(".dialog.duplicate"),
-                              duplicate_account_calculator_path(slug: calculator),
+                              new_account_calculator_path(slug: calculator), 
+                              params: {original_calculator_id: calculator.id},
                               method: :get,
                               autofocus: true,
                               class: "btn btn-green px-4 py-2 ms-3 text-white" %>

--- a/app/views/account/calculators/partials/_form.html.erb
+++ b/app/views/account/calculators/partials/_form.html.erb
@@ -1,4 +1,5 @@
 <%= simple_form_for(calculator, url: polymorphic_path([:account, calculator], locale: I18n.locale), html: { id: dom_id(calculator, :form) }) do |f| %>
+  <%= f.hidden_field :original_calculator_id %>
   <div class="form-group row">
     <div class="my-auto col-12 has-float-label">
       <fieldset class="bordered">

--- a/app/views/account/calculators/show.html.erb
+++ b/app/views/account/calculators/show.html.erb
@@ -9,6 +9,13 @@
     <p class="text-2xl font-extrabold"> <%= @calculator.name %> </p>
   </div>
 
+  <% if @calculator.original_calculator.present? %>
+    <div class="calc-details mb-4">
+      <span class="text-lg showpage-text"><%= t('.fork_for') %>:</span>
+      <p><%= link_to @calculator.original_calculator.name, account_calculator_path(slug: @calculator.original_calculator.slug), class: "text-success underline" %></p>
+    </div>
+  <% end %>
+
   <div class="calc-details mb-4">
     <span class="text-lg showpage-text"><%= t('.slug') %>:</span>
     <p class="font-bold"> <%= @calculator.slug %> </p>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -529,6 +529,8 @@ en:
       partials:
         field_fields:
           value_of_field: "Value of field:"
+      show:
+        fork_for: "Fork for"
     feature_flags:
       submit_button: "Save"
       new_calculator_design:

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -416,6 +416,8 @@ uk:
       partials:
         field_fields:
           value_of_field: "Значення поля:"
+      show:
+        fork_for: "Дубльовано з"
     site_settings:
       edit:
         meta-title: "Налаштування сайту"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,9 +48,7 @@ Rails.application.routes.draw do
     namespace :account do
       root "dashboard#index"
       resources :users, concerns: :paginatable
-      resources :calculators, param: :slug, concerns: :paginatable do
-        get :duplicate, on: :member
-      end
+      resources :calculators, param: :slug, concerns: :paginatable
       resources :categories, concerns: :paginatable
       resources :products, concerns: :paginatable
       resources :histories, only: :index, concerns: :paginatable

--- a/db/migrate/20250605172551_add_original_calculator_to_calculators.rb
+++ b/db/migrate/20250605172551_add_original_calculator_to_calculators.rb
@@ -1,0 +1,5 @@
+class AddOriginalCalculatorToCalculators < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :calculators, :original_calculator, foreign_key: { to_table: :calculators }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,6 +62,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_18_095516) do
     t.text "uk_notes"
     t.text "en_notes"
     t.string "color", default: "#8fba3b"
+    t.bigint "original_calculator_id"
+    t.index ["original_calculator_id"], name: "index_calculators_on_original_calculator_id"
     t.index ["slug"], name: "index_calculators_on_slug", unique: true
   end
 
@@ -263,6 +265,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_18_095516) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "authorizations", "users"
+  add_foreign_key "calculators", "calculators", column: "original_calculator_id"
   add_foreign_key "categories", "fields"
   add_foreign_key "category_categoryables", "categories"
   add_foreign_key "diapers_periods", "categories"

--- a/spec/factories/calculators.rb
+++ b/spec/factories/calculators.rb
@@ -20,5 +20,12 @@ FactoryBot.define do
   factory :calculator do
     en_name { "English Calculator" }
     uk_name { "Український калькулятор" }
+
+    trait :with_field_and_formula do
+      after(:build) do |calculator|
+        calculator.fields << build(:field, var_name: "x", calculator: calculator)
+        calculator.formulas << build(:formula, expression: "x+1", calculator: calculator)
+      end
+    end
   end
 end

--- a/spec/models/calculator_spec.rb
+++ b/spec/models/calculator_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe Calculator, type: :model do
     it { is_expected.to have_one_attached(:logo_picture) }
     it { is_expected.to have_many(:fields).dependent(:destroy) }
     it { is_expected.to have_many(:formulas).dependent(:destroy) }
+    it { is_expected.to belong_to(:original_calculator).class_name("Calculator").optional(true).inverse_of(:duplicate_calculators) }
+    it { is_expected.to have_many(:duplicate_calculators).class_name("Calculator").with_foreign_key("original_calculator_id").dependent(:nullify).inverse_of(:original_calculator) }
   end
 
   describe "logo_placeholder attribute" do

--- a/spec/requests/account/calculators_spec.rb
+++ b/spec/requests/account/calculators_spec.rb
@@ -185,14 +185,4 @@ RSpec.describe "Account::CalculatorsController", type: :request do
       end
     end
   end
-
-  # describe "GET /account/calculators/:slug/duplicate" do
-  #   it "renders new after copying calculator" do
-  #     get duplicate_account_calculator_path(copy.slug)
-
-  #     expect(response).to be_successful
-  #     expect(response).to render_template(:new)
-  #     expect(response.body).to include(copy.en_name)
-  #   end
-  # end
 end

--- a/spec/requests/account/calculators_spec.rb
+++ b/spec/requests/account/calculators_spec.rb
@@ -100,6 +100,19 @@ RSpec.describe "Account::CalculatorsController", type: :request do
         expect(response).to redirect_to(new_user_session_path)
       end
     end
+
+    context "when duplicating an existing calculator" do
+      let(:original_calculator) { create(:calculator, :with_field_and_formula) }
+
+      it "duplicates the calculator and initializes it correctly" do
+        get new_account_calculator_path(original_calculator_id: original_calculator.id)
+
+        expect(response).to be_successful
+        expect(response.body).to include(original_calculator.name)
+        expect(response.body).to include(original_calculator.fields.first.var_name)
+        expect(response.body).to include(original_calculator.formulas.first.expression)
+      end
+    end
   end
 
   describe "PATCH #update" do
@@ -173,13 +186,13 @@ RSpec.describe "Account::CalculatorsController", type: :request do
     end
   end
 
-  describe "GET /account/calculators/:slug/duplicate" do
-    it "renders new after copying calculator" do
-      get duplicate_account_calculator_path(copyable.slug)
+  # describe "GET /account/calculators/:slug/duplicate" do
+  #   it "renders new after copying calculator" do
+  #     get duplicate_account_calculator_path(copy.slug)
 
-      expect(response).to be_successful
-      expect(response).to render_template(:new)
-      expect(response.body).to include(copyable.en_name)
-    end
-  end
+  #     expect(response).to be_successful
+  #     expect(response).to render_template(:new)
+  #     expect(response.body).to include(copy.en_name)
+  #   end
+  # end
 end


### PR DESCRIPTION
## Checklist

- [x] I have added tests to cover my ruby code changes
- [x] I have added screenshots to show the changes on the UI
- [x] I have added a description of the changes to the PR description

## Changes

-add association between original_calculator and duplicate_calculators;

-add original_calculator_id column to the calculators table;

-display information about the original calculator as a link on the calculator’s page;

-updated the duplication logic in the duplicate method to set the copy’s link to the original calculator.

![Untitled_2](https://github.com/user-attachments/assets/1fcd1986-5ac8-43ad-9c3f-1c224fd8a32a)

### What is the current behavior?

As an admin, I currently cannot see the original calculator from which a duplicate was created. This makes it difficult to understand the source of duplication and track the origin of copies.

### What is the expected behavior?

As an admin I want to see the original one calculator (from what it was duplicated) so that I understand the source of the duplication and can track its origin
