### PR TITLE
1072 Search block

### DIFF
--- a/app/assets/stylesheets/pages/calculator.scss
+++ b/app/assets/stylesheets/pages/calculator.scss
@@ -204,6 +204,42 @@
   padding-left: 20px;
 }
 
+.search-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid $success;
+  border-radius: 6px;
+  padding: 2px 12px;
+  height: 42px;
+
+  .search-icon {
+    font-size: 16px;
+    color: $gray;
+  }
+
+  .search-input {
+    border: none;
+    padding-left: 8px;
+
+    &:focus {
+      box-shadow: none;
+    }
+  }
+
+  .clear-button {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background-color: $success;
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+  }
+}
+
 .last-year option:nth-child(1n + 9) {
   display: none;
 }

--- a/app/assets/stylesheets/pages/feature_flags.scss
+++ b/app/assets/stylesheets/pages/feature_flags.scss
@@ -57,7 +57,7 @@ input[type="submit"] {
   color: #fff;
   cursor: pointer;
   font-size: 16px;
-  padding: 10px;
+  padding: 9px;
   min-width: 110px;
   text-align: center;
   @include transition(all 0.5s ease-in-out);

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "clearButton"]
+
+  clear() {
+    this.inputTarget.value = ""    
+    this.clearButtonTarget.classList.add("invisible")
+  }
+
+  input() {
+    this.clearButtonTarget.classList.remove("invisible")
+  }
+}

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags(title: t(".meta-title")) %>
 
 <div class="container">
-  <div class="row mb-5">
+  <div class="row">
     <%= render partial: "account/shared/search_form", locals: {
           q: @q,
           search_url: account_calculators_path,

--- a/app/views/account/calculators/index.html.erb
+++ b/app/views/account/calculators/index.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags(title: t(".meta-title")) %>
 
 <div class="container">
-  <div class="row">
+  <div class="row mb-5">
     <%= render partial: "account/shared/search_form", locals: {
           q: @q,
           search_url: account_calculators_path,

--- a/app/views/account/shared/_search_form.html.erb
+++ b/app/views/account/shared/_search_form.html.erb
@@ -1,5 +1,5 @@
-<div class="col-md-6 d-flex" data-controller="search">
-  <%= search_form_for(q, url: search_url, method: :get ) do |f| %>
+<div class="col-md-6" data-controller="search">
+  <%= search_form_for(q, url: search_url, method: :get, class: "d-flex gap-2 mb-5") do |f| %>
     <div class="search-container">
       <i class="fa-solid fa-search search-icon"></i>
 
@@ -9,5 +9,6 @@
         <i class="fa-solid fa-xmark"></i>
       </button>
     </div>
+    <%= f.button t(".search_button"), class: "btn-grey" %>
   <% end %>
 </div>

--- a/app/views/account/shared/_search_form.html.erb
+++ b/app/views/account/shared/_search_form.html.erb
@@ -1,7 +1,13 @@
-<div class="col-md-6">
-  <%= search_form_for(q, url: search_url, method: :get, class: "d-flex mb-5") do |f| %>
-    <%= f.search_field search_attribute, placeholder: t(".search_placeholder"), class: "form-input me-2" %>
-    <%= f.button t(".search_button"), class: "btn btn-blue px-4 items-center" %>
-    <%= link_to t(".clear_button"), search_url, class: "btn btn-grey px-4 items-center ml-2" %>
+<div class="col-md-6 d-flex" data-controller="search">
+  <%= search_form_for(q, url: search_url, method: :get ) do |f| %>
+    <div class="search-container">
+      <i class="fa-solid fa-search search-icon"></i>
+
+      <%= f.text_field search_attribute, placeholder: t(".search_placeholder"), class: "search-input", data: { search_target: "input", action: "input->search#input" } %>
+
+      <button type="button" class="clear-button invisible" data-action="search#clear" data-search-target="clearButton">
+        <i class="fa-solid fa-xmark"></i>
+      </button>
+    </div>
   <% end %>
 </div>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -277,8 +277,6 @@ en:
     messages:
       index:
         meta-title: "Messages"
-        search_placeholder: "Search"
-        search_button: "Search"
         table:
           title: "Title"
           email: "Email"
@@ -294,8 +292,6 @@ en:
     categories:
       index:
         meta-title: "Categories"
-        search_placeholder: "Search"
-        search_button: "Search"
         table:
           title: "Title"
           actions: "Actions"
@@ -397,35 +393,6 @@ en:
           blocked_label: "Blocked"
           unblocked_label: "Unblocked"
         button: "Back"
-    calculators:
-      index:
-        meta-title: "Calculators"
-        add_calculator_button: "Add calculator"
-        confirm_delete: "Are you sure you want to delete calculator?"
-        table:
-          calculator_slug: "Slug"
-          calculator_name: "Name"
-          calculator_actions: "Actions"
-          show: "Show"
-          edit: "Edit"
-          duplicate: "Duplicate"
-          delete: "Delete"
-        edit:
-          add_new_field_label: "Add new field"
-          form:
-            select_field_kind_label: "Select field kind"
-            select_field_type_label: "Select field type"
-            form_label: "Form"
-            parameters_label: "Parameters"
-            results_label: "Results"
-            no_fields_yet_label: "No fields yet"
-            update_calculator_button: "Update calculator"
-        new:
-          create_calculator_button: "Save calculator"
-          cancel_button: "Сancel"
-          prohibited_to_update: " prevent the calculator from updating"
-          prohibited_to_save: " перешкоджають збереженню калькулятора"
-          error: "помилки"
     site_settings:
       edit:
         meta-title: "Site Settings"
@@ -507,6 +474,9 @@ en:
           calculator_slug: "Slug"
           calculator_name: "Name"
           calculator_actions: "Actions"
+          show: "Show"
+          edit: "Edit"
+          delete: "Delete"
         dialog:
           are_you_sure: "Are you sure?"
           dialog_description: "This will create a duplicate of the calculator with all its settings and data."

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -15,5 +15,5 @@ en:
         donate: "Donate"
         calculators: "Calculators"
       search_form:
-        search_placeholder: "Search"
+        search_placeholder: "Type here"
         search_button: "Search"

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -258,9 +258,7 @@ uk:
         change_password_button: "Змінити пароль"
     messages:
       index:
-        meta-title: "Повідомлення"
-        search_placeholder: "Пошук"
-        search_button: "Шукати"
+        meta-title: "Повідомлення"       
         table:
           title: "Заголовок"
           email: "Електронна пошта"
@@ -276,8 +274,6 @@ uk:
     categories:
       index:
         meta-title: "Категорії"
-        search_placeholder: "Пошук"
-        search_button: "Шукати"
         table:
           title: "Назва"
           actions: "Дії"


### PR DESCRIPTION
## Checklist

- [x] I have added screenshots to show the changes on the UI
- [x] I have added a description of the changes to the PR description

## Changes

-Updated search input field;
-The clear button in the form of a cross appears when text is entered;
-Updated the search button (text remains white on hover);
-Updated translation files

![Capture_14](https://github.com/user-attachments/assets/0e3b07e4-82e6-469a-818f-b302549811e0)

![Capture_15](https://github.com/user-attachments/assets/17b13415-f2cd-40b6-a130-20f01b36dc33)

### What is the current behavior?

-Duplicate of the word "Search";
-Search and clear buttons without indentation;
-Clear with the word "Button";
-When hovering over Clear, the letters turn black, while on the rest of the site (Site Setting) they remain white.

![Capture_12](https://github.com/user-attachments/assets/937eb60a-483b-4287-b848-b8df7a983f3f)

### What is the expected behavior?

Search field:
-сontains a search icon on the left;
-a clear button in the form of a cross appears on the right when text is entered;
-clicking the cross clears the input and hides the button
Search button always has white text.
