### PR TITLE
1068 data entry (default number)

### DIFF
--- a/app/javascript/controllers/mhc_calculator_controller.js
+++ b/app/javascript/controllers/mhc_calculator_controller.js
@@ -14,6 +14,10 @@ export default class extends Controller {
   submit(e) {
     e.preventDefault();
 
+    if (!this.menopauseAgeTarget.value) {
+      this.menopauseAgeTarget.value = "50";
+    }
+
     let formData = {
       user_age: parseInt(this.userAgeTarget.value),
       menstruation_age: parseInt(this.menstruationAgeTarget.value),

--- a/app/views/calculators/mhc_calculator.erb
+++ b/app/views/calculators/mhc_calculator.erb
@@ -33,8 +33,7 @@
 
         <%= form.input_field :menopause_age,
                               type: "number",
-                              class: "form_fild price_select rounded w-100 form-control mb-0 placeholder-neutral-400",
-                              placeholder: "50",
+                              class: "form_fild price_select rounded w-100 form-control mb-0",
                               data: { mhc_calculator_target: "menopauseAge" } %>
 
         <div class="pb-2 input_lable mt-6">

--- a/app/views/calculators/mhc_calculator.erb
+++ b/app/views/calculators/mhc_calculator.erb
@@ -33,7 +33,7 @@
 
         <%= form.input_field :menopause_age,
                               type: "number",
-                              class: "form_fild price_select rounded w-100 form-control mb-0",
+                              class: "form_fild price_select rounded w-100 form-control mb-0 placeholder-neutral-400",
                               placeholder: "50",
                               data: { mhc_calculator_target: "menopauseAge" } %>
 


### PR DESCRIPTION
## Checklist

- [x] I have added screenshots to show the changes on the UI
- [x] I have added a description of the changes to the PR description

## Changes

-added setting the default value 50 in the "Age at Menopause" field;
-remove the placeholder in the "Age at Menopause" field

### What is the current behavior?

The number 50 is set by default, but it needs to be either entered again or a custom option provided. Otherwise, it throws an error that the age has not been entered, which the user can see.

![image](https://github.com/user-attachments/assets/9c56a957-2eeb-4ce6-85a6-61c70b98a93b)

### What is the expected behavior?

-If the user leaves the default number, they should be allowed to enter;
-The number 50 needs to be more transparent.
