### PR TITLE
Add select to constructor

### DIFF
--- a/app/controllers/account/calculators_controller.rb
+++ b/app/controllers/account/calculators_controller.rb
@@ -68,7 +68,8 @@ class Account::CalculatorsController < Account::BaseController
       :id, :en_name, :uk_name, :color, :logo_picture, :uk_notes, :en_notes,
       formulas_attributes: [:id, :expression, :en_label, :uk_label, :calculator_id, :en_unit, :uk_unit, :priority, :formula_image, :relation, :_destroy],
       fields_attributes: [:id, :en_label, :uk_label, :var_name, :kind, :_destroy,
-        categories_attributes: [:id, :en_name, :uk_name, :price, :_destroy]]
+        categories_attributes: [:id, :en_name, :uk_name, :price, :_destroy],
+        select_options_attributes: [:id, :key, :value, :_destroy]]
     )
   end
 

--- a/app/javascript/controllers/field_type_controller.js
+++ b/app/javascript/controllers/field_type_controller.js
@@ -1,24 +1,36 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["fieldTypeSelect", "categoryFields"]
+  static targets = ["fieldTypeSelect", "categoryFields", "selectOptions"]
 
   connect() {
     this.setupFieldTypeSelect();
   }
 
   setupFieldTypeSelect() {
-    if (this.hasFieldTypeSelectTarget && this.hasCategoryFieldsTarget) {
-      this.toggleCategoryFields();
-      this.fieldTypeSelectTarget.addEventListener("change", () => this.toggleCategoryFields());
+    if (this.hasFieldTypeSelectTarget) {
+      this.toggleFields();
+      this.fieldTypeSelectTarget.addEventListener("change", () => this.toggleFields());
     }
   }
 
-  toggleCategoryFields() {
-    if (this.fieldTypeSelectTarget.value === "category") {
-      this.categoryFieldsTarget.style.display = "block";
-    } else {
-      this.categoryFieldsTarget.style.display = "none";
+  toggleFields() {
+    const selected = this.fieldTypeSelectTarget.value;
+
+    if (this.hasCategoryFieldsTarget) {
+      if (selected === "category") {
+        this.categoryFieldsTarget.style.display = "block";
+      } else {
+        this.categoryFieldsTarget.style.display = "none";
+      }
+    }
+
+    if (this.hasSelectOptionsTarget) {
+      if (selected === "select_option") {
+        this.selectOptionsTarget.style.display = "block";
+      } else {
+        this.selectOptionsTarget.style.display = "none";
+      }
     }
   }
 }

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -30,10 +30,12 @@ class Field < ApplicationRecord
   belongs_to :calculator
 
   has_many :categories, dependent: :destroy
+  has_many :select_options, dependent: :destroy
 
   NUMBER   = "number"
   CATEGORY = "category"
-  KINDS    = { number: NUMBER, category: CATEGORY }.freeze
+  SELECT_OPTION = "select_option"
+  KINDS    = { number: NUMBER, category: CATEGORY, select_option: SELECT_OPTION }.freeze
 
   enum :kind, KINDS
   enum :unit, { day: 0, week: 1, month: 2, year: 3, date: 4, times: 5, money: 6, items: 7 }
@@ -45,4 +47,5 @@ class Field < ApplicationRecord
   validates_with FieldValidator
 
   accepts_nested_attributes_for :categories, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :select_options, reject_if: :all_blank, allow_destroy: true
 end

--- a/app/models/select_option.rb
+++ b/app/models/select_option.rb
@@ -1,6 +1,6 @@
 class SelectOption < ApplicationRecord
   belongs_to :field
 
-  validates :key, presence: true
-  validates :value, presence: true
+  validates :key, presence: true, length: { maximum: 50 }
+  validates :value, presence: true, numericality: true
 end

--- a/app/models/select_option.rb
+++ b/app/models/select_option.rb
@@ -1,0 +1,6 @@
+class SelectOption < ApplicationRecord
+  belongs_to :field
+
+  validates :key, presence: true
+  validates :value, presence: true
+end

--- a/app/views/account/calculators/partials/_field_fields.html.erb
+++ b/app/views/account/calculators/partials/_field_fields.html.erb
@@ -27,6 +27,21 @@
       </fieldset>
     </div>
 
+    <div class="hidden select-options" data-field-type-target="selectOptions">
+      <fieldset class="bordered" data-controller="constructors-form-indexing"
+                data-action="cocoon:after-insert->constructors-form-indexing#afterInsert cocoon:after-remove->constructors-form-indexing#afterRemove">
+        <legend class="admin-legend">Select Options</legend>
+
+        <%= f.simple_fields_for :select_options do |option_fields| %>
+          <%= render "account/calculators/partials/select_option_fields", f: option_fields %>
+        <% end %>
+
+        <div class="links">
+          <%= link_to_add_association "+ Add Option", f, :select_options, partial: "account/calculators/partials/select_option_fields", class: "underline" %>
+        </div>
+      </fieldset>
+    </div>
+
     <%= link_to_remove_association "- Remove Field", f, class: "text-red-500 underline" %>
   </div>
 </fieldset>

--- a/app/views/account/calculators/partials/_select_option_fields.html.erb
+++ b/app/views/account/calculators/partials/_select_option_fields.html.erb
@@ -1,0 +1,10 @@
+<div class="bordered nested-fields flex px-2 space-x-10">
+  <div class="mx-3 string required calculator_fields_select_options_key">
+    <%= f.input :key, label: false, placeholder: "Key", wrapper: false, input_html: { class: "form-control", style: "min-width: 120px;" } %>
+  </div>
+
+  <div class="mx-3 string required calculator_fields_select_options_key">
+    <%= f.input :value, label: false, placeholder: "Value", wrapper: false, input_html: { class: "form-control", style: "min-width: 120px;" } %>
+  </div>
+  <%= link_to_remove_association "- Remove Option", f, class: "text-red-500 underline" %>
+</div>

--- a/app/views/calculators/show.html.erb
+++ b/app/views/calculators/show.html.erb
@@ -14,9 +14,14 @@
                                   class: "required rounded w-100 calculator-field"
                                   %>
             </div>
-          <% else %>
+          <% elsif field.kind == 'category' %>
             <%= form.select "inputs[#{field.var_name}]",
                             options_from_collection_for_select(field.categories, :price, :name),
+                            {},
+                            class: "flex-row rounded flex-item w-100 form_fild calculator-field" %>
+          <% elsif field.kind == 'select_option' %>
+            <%= form.select "inputs[#{field.var_name}]",
+                            options_for_select(field.select_options.map { |opt| [opt.key, opt.value] }),
                             {},
                             class: "flex-row rounded flex-item w-100 form_fild calculator-field" %>
           <% end %>

--- a/db/migrate/20250614142313_create_select_options.rb
+++ b/db/migrate/20250614142313_create_select_options.rb
@@ -1,0 +1,11 @@
+class CreateSelectOptions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :select_options do |t|
+      t.references :field, null: false, foreign_key: true
+      t.string :key
+      t.integer :value
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_23_135823) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_14_142313) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -190,6 +190,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_23_135823) do
     t.index ["uuid"], name: "index_products_on_uuid", unique: true
   end
 
+  create_table "select_options", force: :cascade do |t|
+    t.bigint "field_id", null: false
+    t.string "key"
+    t.integer "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["field_id"], name: "index_select_options_on_field_id"
+  end
+
   create_table "site_settings", force: :cascade do |t|
     t.string "title", default: "ZeroWaste", null: false
     t.datetime "created_at", null: false
@@ -247,4 +256,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_23_135823) do
   add_foreign_key "diapers_periods", "categories"
   add_foreign_key "fields", "calculators"
   add_foreign_key "formulas", "calculators"
+  add_foreign_key "select_options", "fields"
 end

--- a/spec/factories/select_options.rb
+++ b/spec/factories/select_options.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :select_option do
+    field { nil }
+    key { "MyString" }
+    value { 1 }
+  end
+end

--- a/spec/factories/select_options.rb
+++ b/spec/factories/select_options.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :select_option do
-    field { nil }
+    association :field
     key { "MyString" }
     value { 1 }
   end

--- a/spec/models/select_option_spec.rb
+++ b/spec/models/select_option_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe SelectOption, type: :model do
+  subject { build(:select_option) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:field) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:key) }
+    it { is_expected.to validate_length_of(:key).is_at_least(1).is_at_most(50) }
+
+    it { is_expected.to validate_presence_of(:value) }
+    it { is_expected.to validate_numericality_of(:value) }
+  end
+
+  context "when key is blank" do
+    let(:select_option) { build(:select_option, key: "") }
+
+    it "returns one error message for blank key" do
+      select_option.valid?
+      expect(select_option.errors.full_messages_for(:key).length).to eq 1
+      expect(select_option.errors.full_messages_for(:key)).to include("Key can't be blank")
+    end
+  end
+
+  context "when value is not a number" do
+    let(:select_option) { build(:select_option, value: "abc") }
+
+    it "is not valid" do
+      expect(select_option).not_to be_valid
+      expect(select_option.errors[:value]).to include("is not a number")
+    end
+  end
+end

--- a/spec/models/select_option_spec.rb
+++ b/spec/models/select_option_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SelectOption, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:key) }
-    it { is_expected.to validate_length_of(:key).is_at_least(1).is_at_most(50) }
+    it { is_expected.to validate_length_of(:key).is_at_most(50) }
 
     it { is_expected.to validate_presence_of(:value) }
     it { is_expected.to validate_numericality_of(:value) }

--- a/spec/models/select_option_spec.rb
+++ b/spec/models/select_option_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe SelectOption, type: :model do
   subject { build(:select_option) }


### PR DESCRIPTION
## Checklist

- [x] I have added tests to cover my ruby code changes
- [x] I have added screenshots to show the changes on the UI
- [x] I have added a description of the changes to the PR description

## Changes

### What is the current behavior?

We have only number and category field types
![image](https://github.com/user-attachments/assets/e9c8f8f2-3b13-4c26-ae5b-e8ae25c46a3e)


### What is the expected behavior?

We have select field type
![image](https://github.com/user-attachments/assets/de19601b-d009-467b-859d-a9aa4b4f98fb)

